### PR TITLE
feat(badge): add RFC-003 Proof of Possession support

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ capiscio rpc --address localhost:50051
 # Python SDK will auto-start the server
 python -c "
 from capiscio_sdk._rpc.client import CapiscioRPCClient
+token = '<YOUR_BADGE_TOKEN_HERE>'  # Replace with your actual badge token
 with CapiscioRPCClient() as client:
     valid, claims, warnings, err = client.badge.verify_badge_with_options(
         token,

--- a/pkg/badge/schema.go
+++ b/pkg/badge/schema.go
@@ -44,7 +44,7 @@ type Claims struct {
 
 	// CNF is the confirmation claim per RFC 7800.
 	// When present, binds the badge to a specific key holder.
-	// Used for Proof of Possession (PoP) badges (RFC-002 §7.2.2, RFC-005).
+	// Used for Proof of Possession (PoP) badges (RFC-002 §7.2.2, RFC-003).
 	CNF *ConfirmationClaim `json:"cnf,omitempty"`
 
 	// PoPChallengeID is a reference to the PoP challenge used during issuance.


### PR DESCRIPTION
## Summary

This PR implements core data structures for RFC-003 Key Ownership Proof protocol and updates documentation for v2.2.0 release.

## Changes

### Badge Schema (`pkg/badge/schema.go`)

New fields for Proof of Possession support:
- `NotBefore` - Token validity start time
- `IAL` - Identity Assurance Level (ial-0, ial-1)
- `CNF` - Confirmation claim for key binding
- `PoPChallengeID` - PoP challenge identifier
- `AgentCardHash` - Binding to agent card document
- `DIDDocHash` - Binding to DID document

New types and methods:
- `ConfirmationClaim` struct for cnf claim parsing
- `AssuranceLevel()` method for IAL extraction
- `HasProofOfPossession()` method for PoP detection

### README.md

Updated for v2.2.0 release:
- Version badge update
- RFC-003 Key Ownership Proof in specifications list
- gRPC SDK integration section with Python examples
- New CLI commands: `badge keep`, `gateway start`, `rpc`, `key gen`
- Enhanced protocol documentation structure

## Related

- RFC-002: Trust Badge v1.1
- RFC-003: Key Ownership Proof Protocol

## Testing

- [ ] Schema changes compile
- [ ] New methods work correctly
- [ ] README examples are accurate