### PR TITLE
chore: bump version to 2.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+## [2.3.1] - 2025-01-14
+
+### Fixed
+- Aligned all version references across package metadata
+
+## [2.3.0] - 2025-01-13
+
+### Added
+- **PoP Client (RFC-003)**: Badge issuance via Proof of Possession protocol for IAL-1 verification
+- **Staleness Fail-Closed (RFC-002 v1.3 §7.5)**: Badges now fail validation when stale (fail-closed security posture)
+
+### Fixed
+- **Integration Tests**: Improved integration test fixtures and assertions
+- **CI Workflow**: Exclude integration tests from release workflow to prevent false failures
+
+### Documentation
+- Comprehensive CLI documentation audit and fixes
+- Added Copilot workspace guidelines
+
 ## [2.2.0] - 2025-12-10
 
 ### Changed

--- a/cmd/capiscio/main.go
+++ b/cmd/capiscio/main.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var version = "2.2.0"
+var version = "2.3.1"
 
 var rootCmd = &cobra.Command{
 	Use:   "capiscio",


### PR DESCRIPTION
## Summary
Bumps version to 2.3.1 to fix version misalignment from the 2.3.0 release.

## Changes
- Updated `cmd/capiscio/main.go` version to 2.3.1
- Added [2.3.0] changelog entry with PoP Client (RFC-003) and Staleness Fail-Closed (RFC-002 v1.3)
- Added [2.3.1] changelog entry

## Context
The 2.3.0 release had version mismatches across packages. This release aligns all CapiscIO packages to 2.3.1.