### PR TITLE
feat(security): add SHA-256 checksums to release artifacts (B5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Build Windows
         run: GOOS=windows GOARCH=amd64 go build -o capiscio-windows-amd64.exe ./cmd/capiscio
 
+      - name: Generate checksums
+        run: sha256sum capiscio-linux-amd64 capiscio-darwin-amd64 capiscio-darwin-arm64 capiscio-windows-amd64.exe > checksums.txt
+
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
@@ -43,6 +46,7 @@ jobs:
             capiscio-darwin-amd64
             capiscio-darwin-arm64
             capiscio-windows-amd64.exe
+            checksums.txt
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

Adds SHA-256 checksum generation to the release workflow (B5 - design partner eval, part 1/3).

### Changes
- Generates `checksums.txt` containing SHA-256 hashes for all 4 release binaries
- Publishes `checksums.txt` as a release asset alongside the binaries

### Related PRs
- capiscio-python: checksum verification in download manager (separate PR)
- capiscio-node: checksum verification in download manager (separate PR)

### Evaluation Plan
Design partner eval item **B5** (P1 — Security)