### PR TITLE
fix: GA-023/024/025 core hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 While it serves as the reference implementation for the **Agent-to-Agent (A2A) Protocol**, its primary mission is to secure the broader agent ecosystem.
 
-> **v2.2.0 Release**: Full implementation of **RFC-002 Trust Badge Specification** and **RFC-003 Key Ownership Proof (PoP)** with did:web/did:key DIDs, Trust Levels, gRPC SDK integration, and enhanced verification.
+> **v2.6.0 Release**: Full implementation of **RFC-002 Trust Badge Specification** and **RFC-003 Key Ownership Proof (PoP)** with did:web/did:key DIDs, Trust Levels, gRPC SDK integration, and enhanced verification.
 
 ## Why CapiscIO?
 
@@ -40,7 +40,7 @@ Building authentication for AI Agents is hard. OAuth is complex, API keys are in
 ### 1. Installation
 
 ```bash
-go install github.com/capiscio/capiscio-core/cmd/capiscio@latest
+go install github.com/capiscio/capiscio-core/v2/cmd/capiscio@latest
 ```
 
 ### 2. Issue a Trust Badge (Identity)

--- a/cmd/capiscio/validate.go
+++ b/cmd/capiscio/validate.go
@@ -48,7 +48,7 @@ var validateCmd = &cobra.Command{
 	Short: "Validate an Agent Card",
 	Long:  `Validate an Agent Card from a local file or URL. Checks compliance, verifies signatures, and optionally tests availability.`,
 	Args:  cobra.ExactArgs(1),
-	RunE: func(_ *cobra.Command, args []string) error {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if flagLive {
 			fmt.Fprintln(os.Stderr, "Warning: --live is deprecated and will be removed in v1.1.0. Please use --test-live instead.")
 		}
@@ -59,7 +59,7 @@ var validateCmd = &cobra.Command{
 
 		// 1. Load Data
 		if strings.HasPrefix(input, "http://") || strings.HasPrefix(input, "https://") {
-			ctx, cancel := context.WithTimeout(context.Background(), flagTimeout)
+			ctx, cancel := context.WithTimeout(cmd.Context(), flagTimeout)
 			defer cancel()
 
 			req, err := http.NewRequestWithContext(ctx, http.MethodGet, input, nil)
@@ -78,7 +78,9 @@ var validateCmd = &cobra.Command{
 				return fmt.Errorf("URL returned HTTP %d (%s)", resp.StatusCode, resp.Status)
 			}
 
-			cardData, err = io.ReadAll(resp.Body)
+			// Limit response body to 10MB to prevent memory exhaustion
+			const maxBodySize = 10 << 20
+			cardData, err = io.ReadAll(io.LimitReader(resp.Body, maxBodySize))
 			if err != nil {
 				return fmt.Errorf("failed to read response body: %w", err)
 			}

--- a/cmd/capiscio/validate.go
+++ b/cmd/capiscio/validate.go
@@ -59,11 +59,25 @@ var validateCmd = &cobra.Command{
 
 		// 1. Load Data
 		if strings.HasPrefix(input, "http://") || strings.HasPrefix(input, "https://") {
-			resp, err := http.Get(input)
+			ctx, cancel := context.WithTimeout(context.Background(), flagTimeout)
+			defer cancel()
+
+			req, err := http.NewRequestWithContext(ctx, http.MethodGet, input, nil)
+			if err != nil {
+				return fmt.Errorf("failed to create request: %w", err)
+			}
+
+			client := &http.Client{Timeout: flagTimeout}
+			resp, err := client.Do(req)
 			if err != nil {
 				return fmt.Errorf("failed to fetch URL: %w", err)
 			}
 			defer func() { _ = resp.Body.Close() }()
+
+			if resp.StatusCode != http.StatusOK {
+				return fmt.Errorf("URL returned HTTP %d (%s)", resp.StatusCode, resp.Status)
+			}
+
 			cardData, err = io.ReadAll(resp.Body)
 			if err != nil {
 				return fmt.Errorf("failed to read response body: %w", err)

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,7 +4,7 @@
 
 While it serves as the reference implementation for the **Agent-to-Agent (A2A) Protocol**, its primary mission is to secure the broader agent ecosystem.
 
-> **v1.0.2 Release**: This release combines the **Validation Engine** (for A2A compliance) with the new **Authority Layer** (for runtime security).
+> **v2.6.0 Release**: Full implementation of **RFC-002 Trust Badge Specification** and **RFC-003 Key Ownership Proof (PoP)** with did:web/did:key DIDs, Trust Levels, gRPC SDK integration, and enhanced verification.
 
 ## Why CapiscIO?
 
@@ -32,7 +32,7 @@ Building authentication for AI Agents is hard. OAuth is complex, API keys are in
 ### 1. Installation
 
 ```bash
-go install github.com/capiscio/capiscio-core/cmd/capiscio@v1.0.2
+go install github.com/capiscio/capiscio-core/v2/cmd/capiscio@latest
 ```
 
 ### 2. Initialize Your Agent (One Command)
@@ -141,8 +141,8 @@ CapiscIO Core retains its original capabilities as a robust validator for the A2
 
 ```go
 import (
-    "github.com/capiscio/capiscio-core/pkg/badge"
-    "github.com/capiscio/capiscio-core/pkg/registry"
+    "github.com/capiscio/capiscio-core/v2/pkg/badge"
+    "github.com/capiscio/capiscio-core/v2/pkg/registry"
 )
 
 func main() {
@@ -166,8 +166,8 @@ func main() {
 
 ```go
 import (
-    "github.com/capiscio/capiscio-core/pkg/agentcard"
-    "github.com/capiscio/capiscio-core/pkg/scoring"
+    "github.com/capiscio/capiscio-core/v2/pkg/agentcard"
+    "github.com/capiscio/capiscio-core/v2/pkg/scoring"
 )
 
 func main() {
@@ -195,7 +195,7 @@ For complete command usage and flags, see the [CLI Reference](./reference/cli.md
 ## Development
 
 ### Prerequisites
-- Go 1.21+
+- Go 1.25+
 
 ### Testing
 ```bash

--- a/internal/rpc/server.go
+++ b/internal/rpc/server.go
@@ -34,10 +34,13 @@ func RegisterServices(server *grpc.Server) {
 		pb.RegisterTrustStoreServiceServer(server, trustService)
 	}
 
-	pb.RegisterRevocationServiceServer(server, NewRevocationService())
 	pb.RegisterScoringServiceServer(server, NewScoringService())
 	pb.RegisterSimpleGuardServiceServer(server, NewSimpleGuardService())
-	pb.RegisterRegistryServiceServer(server, NewRegistryService())
+
+	// TODO(GA+1): Implement and register RegistryService and RevocationService.
+	// Currently stub-only — registering unimplemented services is misleading.
+	// pb.RegisterRevocationServiceServer(server, NewRevocationService())
+	// pb.RegisterRegistryServiceServer(server, NewRegistryService())
 
 	// Register MCPService for RFC-006/007 MCP integration
 	pb.RegisterMCPServiceServer(server, NewMCPService())


### PR DESCRIPTION
## GA Remediation — Core Hardening (T1)

### GA-023: Fix docs/README version drift
- Update version references from v1.0.2/v2.2.0 to v2.6.0
- Fix install command to use `/v2` module path
- Fix import paths in docs to include `/v2`
- Update Go prerequisite from 1.21+ to 1.25+

### GA-024: Unregister stub gRPC services
- Remove RegistryService and RevocationService from gRPC registration
- Both are TODO-only stubs that return misleading success responses
- Services retained in codebase for future implementation (GA+1)

### GA-025: Add timeout to CLI validate URL fetch
- Replace `http.Get` with `http.Client` using configurable `--timeout` flag
- Add `context.WithTimeout` for cancellation support
- Check HTTP status code before reading body

**Tests pass**: `go test ./internal/rpc/ ./cmd/capiscio/` ✅