### PR TITLE
[security] Core hardening: nbf enforcement, secure defaults, JWKS cap, cache shutdown, constant-time compare

### DIFF
--- a/internal/rpc/badge_service.go
+++ b/internal/rpc/badge_service.go
@@ -142,12 +142,13 @@ func (s *BadgeService) parseJWSToken(token string) (*jose.JSONWebSignature, *bad
 
 // buildVerifyOptions constructs verification options from the request.
 func (s *BadgeService) buildVerifyOptions(req *pb.VerifyBadgeWithOptionsRequest) badge.VerifyOptions {
-	// Return defaults when no options provided
+	// Return secure defaults when no options provided.
+	// Revocation and agent status checks are enabled by default.
 	if req.Options == nil {
 		return badge.VerifyOptions{
 			Mode:                 badge.VerifyModeOnline,
-			SkipRevocationCheck:  true,
-			SkipAgentStatusCheck: true,
+			SkipRevocationCheck:  false,
+			SkipAgentStatusCheck: false,
 		}
 	}
 

--- a/pkg/badge/verifier.go
+++ b/pkg/badge/verifier.go
@@ -402,6 +402,11 @@ func (v *Verifier) validateClaims(claims *Claims, opts VerifyOptions, now time.T
 		return NewError(ErrCodeNotYetValid, fmt.Sprintf("badge not valid until %s", time.Unix(claims.IssuedAt, 0).Format(time.RFC3339)))
 	}
 
+	// Step 6b2: nbf <= current_time (not before validity window)
+	if claims.NotBefore > 0 && claims.NotBefore > nowUnix {
+		return NewError(ErrCodeNotYetValid, fmt.Sprintf("badge not valid before %s", time.Unix(claims.NotBefore, 0).Format(time.RFC3339)))
+	}
+
 	// Step 6c: Issuer in trusted issuer list (unless self-signed with AcceptSelfSigned)
 	if len(opts.TrustedIssuers) > 0 && !isSelfSigned {
 		trusted := false

--- a/pkg/badge/verifier.go
+++ b/pkg/badge/verifier.go
@@ -389,9 +389,7 @@ func (v *Verifier) validateStructure(jwsObj *jose.JSONWebSignature, claims *Clai
 }
 
 // validateClaims performs claim validation per RFC-002 §8.1 step 6.
-func (v *Verifier) validateClaims(claims *Claims, opts VerifyOptions, now time.Time, isSelfSigned bool) error {
-	nowUnix := now.Unix()
-
+func (v *Verifier) validateTimeClaims(claims *Claims, nowUnix int64) error {
 	// Step 6a: exp > current_time (not expired)
 	if claims.Expiry <= nowUnix {
 		return NewError(ErrCodeExpired, fmt.Sprintf("badge expired at %s", time.Unix(claims.Expiry, 0).Format(time.RFC3339)))
@@ -405,6 +403,16 @@ func (v *Verifier) validateClaims(claims *Claims, opts VerifyOptions, now time.T
 	// Step 6b2: nbf <= current_time (not before validity window)
 	if claims.NotBefore > 0 && claims.NotBefore > nowUnix {
 		return NewError(ErrCodeNotYetValid, fmt.Sprintf("badge not valid before %s", time.Unix(claims.NotBefore, 0).Format(time.RFC3339)))
+	}
+
+	return nil
+}
+
+func (v *Verifier) validateClaims(claims *Claims, opts VerifyOptions, now time.Time, isSelfSigned bool) error {
+	nowUnix := now.Unix()
+
+	if err := v.validateTimeClaims(claims, nowUnix); err != nil {
+		return err
 	}
 
 	// Step 6c: Issuer in trusted issuer list (unless self-signed with AcceptSelfSigned)

--- a/pkg/crypto/jwks.go
+++ b/pkg/crypto/jwks.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"sync"
 	"time"
@@ -82,7 +83,7 @@ func (f *DefaultJWKSFetcher) Fetch(ctx context.Context, url string) (*jose.JSONW
 	}
 
 	var jwks jose.JSONWebKeySet
-	if err := json.NewDecoder(resp.Body).Decode(&jwks); err != nil {
+	if err := json.NewDecoder(io.LimitReader(resp.Body, 1<<20)).Decode(&jwks); err != nil {
 		return nil, fmt.Errorf("failed to decode JWKS: %w", err)
 	}
 

--- a/pkg/pop/session_cache.go
+++ b/pkg/pop/session_cache.go
@@ -22,6 +22,7 @@ type SessionCache struct {
 	mu      sync.RWMutex
 	entries map[string]*CacheEntry
 	config  *CacheConfig
+	done    chan struct{}
 }
 
 // CacheConfig configures session cache behavior
@@ -79,6 +80,7 @@ func NewSessionCache(config *CacheConfig) *SessionCache {
 	cache := &SessionCache{
 		entries: make(map[string]*CacheEntry),
 		config:  config,
+		done:    make(chan struct{}),
 	}
 
 	// Start background cleanup if configured
@@ -197,13 +199,24 @@ func (c *SessionCache) Size() int {
 	return len(c.entries)
 }
 
+// Close stops the background cleanup goroutine.
+func (c *SessionCache) Close() error {
+	close(c.done)
+	return nil
+}
+
 // cleanupLoop periodically removes expired entries
 func (c *SessionCache) cleanupLoop() {
 	ticker := time.NewTicker(c.config.CleanupInterval)
 	defer ticker.Stop()
 
-	for range ticker.C {
-		c.cleanup()
+	for {
+		select {
+		case <-ticker.C:
+			c.cleanup()
+		case <-c.done:
+			return
+		}
 	}
 }
 

--- a/pkg/pop/session_cache.go
+++ b/pkg/pop/session_cache.go
@@ -19,10 +19,11 @@ import (
 
 // SessionCache provides thread-safe caching of PoP verification results
 type SessionCache struct {
-	mu      sync.RWMutex
-	entries map[string]*CacheEntry
-	config  *CacheConfig
-	done    chan struct{}
+	mu       sync.RWMutex
+	entries  map[string]*CacheEntry
+	config   *CacheConfig
+	done     chan struct{}
+	closeOnce sync.Once
 }
 
 // CacheConfig configures session cache behavior
@@ -199,9 +200,11 @@ func (c *SessionCache) Size() int {
 	return len(c.entries)
 }
 
-// Close stops the background cleanup goroutine.
+// Close stops the background cleanup goroutine. Safe to call multiple times.
 func (c *SessionCache) Close() error {
-	close(c.done)
+	c.closeOnce.Do(func() {
+		close(c.done)
+	})
 	return nil
 }
 

--- a/pkg/simpleguard/guard.go
+++ b/pkg/simpleguard/guard.go
@@ -4,6 +4,7 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"crypto/sha256"
+	"crypto/subtle"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -157,7 +158,7 @@ func (g *SimpleGuard) VerifyInbound(token string, body []byte) (*Claims, error) 
 		hash := sha256.Sum256(body)
 		expectedHash := base64.RawURLEncoding.EncodeToString(hash[:])
 
-		if claims.BodyHash != expectedHash {
+		if subtle.ConstantTimeCompare([]byte(claims.BodyHash), []byte(expectedHash)) != 1 {
 			return nil, fmt.Errorf("%w: expected %s, got %s", ErrIntegrityFailed, expectedHash, claims.BodyHash)
 		}
 	} else if claims.BodyHash != "" {


### PR DESCRIPTION
## Security Audit Remediation — Phase 1 Core Hardening

Addresses SEC-CORE-006, 007, 008, 012, 013 from the security audit.

### Changes

| Task | Severity | Description |
|------|----------|-------------|
| SEC-CORE-006 | Medium | Enforce `nbf` (not-before) on badge verification — rejects future-dated badges |
| SEC-CORE-007 | Medium | **Breaking**: RPC verification defaults to revocation + status checks **enabled** (was disabled). Callers relying on lenient defaults must explicitly opt out. |
| SEC-CORE-008 | Medium | JWKS fetch body capped at 1 MiB via `io.LimitReader` |
| SEC-CORE-012 | Low | `SessionCache.Close()` method for clean goroutine shutdown |
| SEC-CORE-013 | Low | Body hash comparison via `subtle.ConstantTimeCompare` |

### Breaking Changes
- **SEC-CORE-007**: `buildVerifyOptions` no longer defaults `SkipRevocationCheck`/`SkipAgentStatusCheck` to `true`. This is the correct secure-by-default behavior.

### Testing
All existing tests pass.