### PR TITLE
feat: implement RFC-008 Authority Envelopes

### DIFF
--- a/cmd/capiscio/envelope.go
+++ b/cmd/capiscio/envelope.go
@@ -33,12 +33,8 @@ var (
 	envDeriveKeyFile  string
 
 	// Envelope verify flags
-	envVerifyKeyFile        string
 	envSkipBadge            bool
 	envVerifyMinMode        string
-
-	// Envelope chain flags
-	envChainFiles []string
 )
 
 var envelopeCmd = &cobra.Command{

--- a/cmd/capiscio/envelope.go
+++ b/cmd/capiscio/envelope.go
@@ -1,0 +1,418 @@
+package main
+
+import (
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/capiscio/capiscio-core/v2/pkg/did"
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
+	"github.com/google/uuid"
+	"github.com/spf13/cobra"
+)
+
+var (
+	// Envelope issue flags
+	envIssuerDID   string
+	envSubjectDID  string
+	envCapability  string
+	envDepth       int
+	envExpiry      time.Duration
+	envKeyFile     string
+	envConstraints string
+	envMinMode     string
+	envTxnID       string
+	envBadgeJTI    string
+
+	// Envelope derive flags
+	envParentFile     string
+	envDeriveKeyFile  string
+
+	// Envelope verify flags
+	envVerifyKeyFile        string
+	envSkipBadge            bool
+	envVerifyMinMode        string
+
+	// Envelope chain flags
+	envChainFiles []string
+)
+
+var envelopeCmd = &cobra.Command{
+	Use:   "envelope",
+	Short: "Manage Authority Envelopes (RFC-008)",
+	Long: `Manage Authority Envelopes for delegated capability authorization.
+
+Authority Envelopes are signed JWS tokens that grant capabilities to agents
+and can be delegated through chains with monotonically narrowing permissions.
+See RFC-008 for the full specification.`,
+}
+
+var envIssueCmd = &cobra.Command{
+	Use:   "issue",
+	Short: "Issue a root Authority Envelope",
+	Long: `Issue a root Authority Envelope.
+
+A root envelope has no parent and establishes the initial capability grant.
+
+Examples:
+  # Issue a root envelope (auto-generates keys)
+  capiscio envelope issue --subject did:key:z6Mk... --capability tools.database --depth 5
+
+  # Issue with a specific key file
+  capiscio envelope issue --key issuer.jwk --subject did:key:z6Mk... --capability tools.database.read --depth 3`,
+	RunE: runEnvIssue,
+}
+
+var envDeriveCmd = &cobra.Command{
+	Use:   "derive",
+	Short: "Derive a child envelope from a parent",
+	Long: `Derive a child Authority Envelope from a parent envelope.
+
+The child must have narrower or equal permissions compared to the parent
+across all four dimensions: capability scope, temporal bounds, depth, and constraints.
+
+Examples:
+  capiscio envelope derive --parent root.env --key child.jwk --subject did:key:z6Mk... --capability tools.database.read --depth 2`,
+	RunE: runEnvDerive,
+}
+
+var envVerifyCmd = &cobra.Command{
+	Use:   "verify [envelope-file]",
+	Short: "Verify an Authority Envelope",
+	Long: `Verify an Authority Envelope's signature, temporal validity, and structure.
+
+Examples:
+  capiscio envelope verify envelope.jws
+  capiscio envelope verify --skip-badge envelope.jws`,
+	Args: cobra.ExactArgs(1),
+	RunE: runEnvVerify,
+}
+
+var envChainCmd = &cobra.Command{
+	Use:   "chain [envelope-files...]",
+	Short: "Verify a chain of Authority Envelopes",
+	Long: `Verify a delegation chain of Authority Envelopes (root-to-leaf order).
+
+Validates hash links, DID continuity, narrowing rules, and signatures.
+
+Examples:
+  capiscio envelope chain root.env child1.env child2.env`,
+	Args: cobra.MinimumNArgs(1),
+	RunE: runEnvChain,
+}
+
+var envInspectCmd = &cobra.Command{
+	Use:   "inspect [envelope-file]",
+	Short: "Inspect an Authority Envelope without verification",
+	Long: `Parse and display the contents of an Authority Envelope without signature verification.
+
+Examples:
+  capiscio envelope inspect envelope.jws`,
+	Args: cobra.ExactArgs(1),
+	RunE: runEnvInspect,
+}
+
+func runEnvIssue(cmd *cobra.Command, args []string) error {
+	var priv, pub, err = loadOrGenerateKey(envKeyFile)
+	if err != nil {
+		return err
+	}
+
+	issuerDID := envIssuerDID
+	if issuerDID == "" {
+		issuerDID = did.NewKeyDID(pub)
+	}
+
+	subjectDID := envSubjectDID
+	if subjectDID == "" {
+		return fmt.Errorf("--subject is required")
+	}
+
+	txnID := envTxnID
+	if txnID == "" {
+		txnID = uuid.New().String()
+	}
+
+	badgeJTI := envBadgeJTI
+	if badgeJTI == "" {
+		badgeJTI = uuid.New().String()
+	}
+
+	now := time.Now()
+	payload := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                issuerDID,
+		SubjectDID:               subjectDID,
+		TxnID:                    txnID,
+		CapabilityClass:          envCapability,
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: envDepth,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(envExpiry).Unix(),
+		IssuerBadgeJTI:           badgeJTI,
+	}
+
+	if envMinMode != "" {
+		payload.EnforcementModeMin = &envMinMode
+	}
+
+	if envConstraints != "" {
+		var constraints map[string]any
+		if err := json.Unmarshal([]byte(envConstraints), &constraints); err != nil {
+			return fmt.Errorf("invalid constraints JSON: %w", err)
+		}
+		payload.Constraints = constraints
+	}
+
+	kid := issuerDID + "#key-1"
+	token, err := envelope.SignEnvelope(payload, priv, kid)
+	if err != nil {
+		return fmt.Errorf("failed to sign envelope: %w", err)
+	}
+
+	fmt.Println(token)
+	return nil
+}
+
+func runEnvDerive(cmd *cobra.Command, args []string) error {
+	// Load parent envelope
+	parentData, err := os.ReadFile(envParentFile)
+	if err != nil {
+		return fmt.Errorf("failed to read parent envelope: %w", err)
+	}
+	parentToken, err := envelope.ParseToken(string(parentData))
+	if err != nil {
+		return fmt.Errorf("failed to parse parent envelope: %w", err)
+	}
+
+	priv, pub, err := loadOrGenerateKey(envDeriveKeyFile)
+	if err != nil {
+		return err
+	}
+
+	issuerDID := envIssuerDID
+	if issuerDID == "" {
+		issuerDID = did.NewKeyDID(pub)
+	}
+
+	subjectDID := envSubjectDID
+	if subjectDID == "" {
+		return fmt.Errorf("--subject is required")
+	}
+
+	now := time.Now()
+	childPayload := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                issuerDID,
+		SubjectDID:               subjectDID,
+		TxnID:                    parentToken.Payload.TxnID,
+		CapabilityClass:          envCapability,
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: envDepth,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(envExpiry).Unix(),
+		IssuerBadgeJTI:           envBadgeJTI,
+	}
+
+	if envMinMode != "" {
+		childPayload.EnforcementModeMin = &envMinMode
+	}
+
+	if envConstraints != "" {
+		var constraints map[string]any
+		if err := json.Unmarshal([]byte(envConstraints), &constraints); err != nil {
+			return fmt.Errorf("invalid constraints JSON: %w", err)
+		}
+		childPayload.Constraints = constraints
+	}
+
+	kid := issuerDID + "#key-1"
+	token, err := envelope.DeriveEnvelope(parentToken, childPayload, priv, kid)
+	if err != nil {
+		return fmt.Errorf("failed to derive envelope: %w", err)
+	}
+
+	fmt.Println(token)
+	return nil
+}
+
+func runEnvVerify(cmd *cobra.Command, args []string) error {
+	data, err := os.ReadFile(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to read envelope file: %w", err)
+	}
+
+	v := &envelope.Verifier{
+		KeyResolver: envelope.DefaultKeyResolver,
+	}
+
+	minMode := envelope.EMObserve
+	if envVerifyMinMode != "" {
+		minMode, err = envelope.ParseEnforcementMode(envVerifyMinMode)
+		if err != nil {
+			return err
+		}
+	}
+
+	result, err := v.VerifyEnvelope(context.Background(), string(data), "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: envSkipBadge,
+		EnforcementMode:       minMode,
+	})
+	if err != nil {
+		return fmt.Errorf("envelope verification failed: %w", err)
+	}
+
+	output := map[string]any{
+		"status":          "VALID",
+		"envelope_id":     result.Payload.EnvelopeID,
+		"issuer_did":      result.Payload.IssuerDID,
+		"subject_did":     result.Payload.SubjectDID,
+		"capability":      result.Payload.CapabilityClass,
+		"depth_remaining": result.Payload.DelegationDepthRemaining,
+		"effective_mode":  result.EffectiveMode.String(),
+		"is_root":         result.Payload.IsRoot(),
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(output)
+}
+
+func runEnvChain(cmd *cobra.Command, args []string) error {
+	envelopes := make([]string, 0, len(args))
+	for _, file := range args {
+		data, err := os.ReadFile(file)
+		if err != nil {
+			return fmt.Errorf("failed to read %s: %w", file, err)
+		}
+		envelopes = append(envelopes, string(data))
+	}
+
+	v := &envelope.Verifier{
+		KeyResolver: envelope.DefaultKeyResolver,
+	}
+
+	result, err := v.VerifyChain(context.Background(), envelopes, map[string]string{}, envelope.VerifyOptions{
+		SkipBadgeVerification: envSkipBadge,
+	})
+	if err != nil {
+		return fmt.Errorf("chain verification failed: %w", err)
+	}
+
+	output := map[string]any{
+		"status":          "VALID",
+		"total_depth":     result.TotalDepth,
+		"root_capability": result.RootCapability,
+		"leaf_capability": result.LeafCapability,
+		"chain_length":    len(result.Links),
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(output)
+}
+
+func runEnvInspect(cmd *cobra.Command, args []string) error {
+	data, err := os.ReadFile(args[0])
+	if err != nil {
+		return fmt.Errorf("failed to read envelope file: %w", err)
+	}
+
+	token, err := envelope.ParseToken(string(data))
+	if err != nil {
+		return fmt.Errorf("failed to parse envelope: %w", err)
+	}
+
+	output := map[string]any{
+		"envelope_id":               token.Payload.EnvelopeID,
+		"issuer_did":                token.Payload.IssuerDID,
+		"subject_did":               token.Payload.SubjectDID,
+		"txn_id":                    token.Payload.TxnID,
+		"capability_class":          token.Payload.CapabilityClass,
+		"constraints":               token.Payload.Constraints,
+		"delegation_depth_remaining": token.Payload.DelegationDepthRemaining,
+		"issued_at":                 token.Payload.IssuedAt,
+		"expires_at":                token.Payload.ExpiresAt,
+		"issuer_badge_jti":          token.Payload.IssuerBadgeJTI,
+		"is_root":                   token.Payload.IsRoot(),
+	}
+
+	if token.Payload.ParentAuthorityHash != nil {
+		output["parent_authority_hash"] = *token.Payload.ParentAuthorityHash
+	}
+	if token.Payload.SubjectBadgeJTI != nil {
+		output["subject_badge_jti"] = *token.Payload.SubjectBadgeJTI
+	}
+	if token.Payload.EnforcementModeMin != nil {
+		output["enforcement_mode_min"] = *token.Payload.EnforcementModeMin
+	}
+
+	output["hash"] = envelope.ComputeHash(string(data))
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(output)
+}
+
+// loadOrGenerateKey loads a key from file or generates a new Ed25519 key pair.
+func loadOrGenerateKey(keyFilePath string) (any, []byte, error) {
+	if keyFilePath != "" {
+		priv, pub, err := loadPrivateKey(keyFilePath)
+		if err != nil {
+			return nil, nil, err
+		}
+		return priv, pub, nil
+	}
+
+	// Auto-generate
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to generate Ed25519 key: %w", err)
+	}
+	fmt.Fprintln(os.Stderr, "Auto-generated Ed25519 key pair (use --key to provide your own)")
+	return priv, pub, nil
+}
+
+func init() {
+	rootCmd.AddCommand(envelopeCmd)
+	envelopeCmd.AddCommand(envIssueCmd)
+	envelopeCmd.AddCommand(envDeriveCmd)
+	envelopeCmd.AddCommand(envVerifyCmd)
+	envelopeCmd.AddCommand(envChainCmd)
+	envelopeCmd.AddCommand(envInspectCmd)
+
+	// Issue flags
+	envIssueCmd.Flags().StringVar(&envIssuerDID, "issuer", "", "Issuer DID (auto-derived from key if not set)")
+	envIssueCmd.Flags().StringVar(&envSubjectDID, "subject", "", "Subject DID (required)")
+	envIssueCmd.Flags().StringVar(&envCapability, "capability", "", "Capability class (e.g. tools.database.read)")
+	envIssueCmd.Flags().IntVar(&envDepth, "depth", 0, "Maximum delegation depth remaining")
+	envIssueCmd.Flags().DurationVar(&envExpiry, "expiry", 1*time.Hour, "Envelope expiry duration")
+	envIssueCmd.Flags().StringVar(&envKeyFile, "key", "", "Path to issuer private key file (JWK)")
+	envIssueCmd.Flags().StringVar(&envConstraints, "constraints", "", "Constraints as JSON object")
+	envIssueCmd.Flags().StringVar(&envMinMode, "min-mode", "", "Minimum enforcement mode (EM-OBSERVE|EM-GUARD|EM-DELEGATE|EM-STRICT)")
+	envIssueCmd.Flags().StringVar(&envTxnID, "txn-id", "", "Transaction ID (auto-generated if not set)")
+	envIssueCmd.Flags().StringVar(&envBadgeJTI, "badge-jti", "", "Issuer badge JTI (auto-generated if not set)")
+
+	// Derive flags
+	envDeriveCmd.Flags().StringVar(&envParentFile, "parent", "", "Path to parent envelope file (required)")
+	envDeriveCmd.Flags().StringVar(&envSubjectDID, "subject", "", "Subject DID (required)")
+	envDeriveCmd.Flags().StringVar(&envCapability, "capability", "", "Capability class (must be within parent scope)")
+	envDeriveCmd.Flags().IntVar(&envDepth, "depth", 0, "Delegation depth remaining (must be less than parent)")
+	envDeriveCmd.Flags().DurationVar(&envExpiry, "expiry", 30*time.Minute, "Envelope expiry duration")
+	envDeriveCmd.Flags().StringVar(&envDeriveKeyFile, "key", "", "Path to issuer private key file (JWK)")
+	envDeriveCmd.Flags().StringVar(&envConstraints, "constraints", "", "Constraints as JSON object")
+	envDeriveCmd.Flags().StringVar(&envMinMode, "min-mode", "", "Minimum enforcement mode")
+	envDeriveCmd.Flags().StringVar(&envIssuerDID, "issuer", "", "Issuer DID (auto-derived from key if not set)")
+	envDeriveCmd.Flags().StringVar(&envBadgeJTI, "badge-jti", "", "Issuer badge JTI")
+
+	// Verify flags
+	envVerifyCmd.Flags().BoolVar(&envSkipBadge, "skip-badge", false, "Skip badge verification (testing only)")
+	envVerifyCmd.Flags().StringVar(&envVerifyMinMode, "min-mode", "", "Required minimum enforcement mode")
+
+	// Chain flags (uses same verify flags)
+	envChainCmd.Flags().BoolVar(&envSkipBadge, "skip-badge", false, "Skip badge verification (testing only)")
+}

--- a/pkg/envelope/capability.go
+++ b/pkg/envelope/capability.go
@@ -1,0 +1,42 @@
+package envelope
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// capabilitySegmentRegex validates a single capability class segment.
+// Each segment must match [a-z][a-z0-9_]* per RFC-008 §7.
+var capabilitySegmentRegex = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)
+
+// ValidateCapabilityClass checks that a capability class string is valid.
+// It must be dot-delimited with each segment matching [a-z][a-z0-9_]*.
+func ValidateCapabilityClass(class string) error {
+	if class == "" {
+		return NewError(ErrCodeCapabilityInvalid, "capability_class is required")
+	}
+
+	segments := strings.Split(class, ".")
+	for i, seg := range segments {
+		if seg == "" {
+			return NewError(ErrCodeCapabilityInvalid,
+				fmt.Sprintf("empty segment at position %d in %q", i, class))
+		}
+		if !capabilitySegmentRegex.MatchString(seg) {
+			return NewError(ErrCodeCapabilityInvalid,
+				fmt.Sprintf("invalid segment %q at position %d in %q: must match [a-z][a-z0-9_]*", seg, i, class))
+		}
+	}
+
+	return nil
+}
+
+// IsWithinScope returns true if child is within the scope of parent.
+// Per RFC-008 §7.2: child == parent OR child starts with parent + ".".
+func IsWithinScope(child, parent string) bool {
+	if child == parent {
+		return true
+	}
+	return strings.HasPrefix(child, parent+".")
+}

--- a/pkg/envelope/capability_test.go
+++ b/pkg/envelope/capability_test.go
@@ -1,0 +1,75 @@
+package envelope_test
+
+import (
+	"testing"
+
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateCapabilityClass(t *testing.T) {
+	tests := []struct {
+		name    string
+		class   string
+		wantErr bool
+	}{
+		{"single segment", "tools", false},
+		{"two segments", "tools.database", false},
+		{"three segments", "tools.database.read", false},
+		{"with underscore", "tools.db_read", false},
+		{"with number", "tools.v2", false},
+		{"complex valid", "a.b_c.d1e2", false},
+
+		{"empty string", "", true},
+		{"uppercase", "Tools", true},
+		{"leading dot", ".tools", true},
+		{"trailing dot", "tools.", true},
+		{"double dot", "tools..database", true},
+		{"starts with number", "tools.1invalid", true},
+		{"contains dash", "tools.db-read", true},
+		{"contains space", "tools. read", true},
+		{"uppercase mixed", "tools.Database", true},
+		{"starts with underscore", "tools._private", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := envelope.ValidateCapabilityClass(tt.class)
+			if tt.wantErr {
+				require.Error(t, err)
+				var envErr *envelope.Error
+				require.ErrorAs(t, err, &envErr)
+				assert.Equal(t, "ENVELOPE_CAPABILITY_INVALID", envErr.Code)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestIsWithinScope(t *testing.T) {
+	tests := []struct {
+		name   string
+		child  string
+		parent string
+		want   bool
+	}{
+		{"same class", "tools", "tools", true},
+		{"child is deeper", "tools.database", "tools", true},
+		{"child is much deeper", "tools.database.read.query", "tools", true},
+		{"exact two-level match", "tools.database", "tools.database", true},
+
+		{"parent is deeper", "tools", "tools.database", false},
+		{"unrelated class", "files.write", "tools.database", false},
+		{"partial prefix but not segment boundary", "tools_extra", "tools", false},
+		{"sibling", "tools.filesystem", "tools.database", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := envelope.IsWithinScope(tt.child, tt.parent)
+			assert.Equal(t, tt.want, result)
+		})
+	}
+}

--- a/pkg/envelope/chain.go
+++ b/pkg/envelope/chain.go
@@ -1,0 +1,88 @@
+package envelope
+
+import (
+	"crypto"
+	"fmt"
+)
+
+// Chain is an ordered list of envelope tokens [E₀, E₁, ..., Eₙ].
+// E₀ is the root (parent_authority_hash == nil).
+type Chain []*Token
+
+// DeriveEnvelope creates a derived (child) envelope from a parent envelope.
+// It computes the parent_authority_hash, validates narrowing, and signs.
+// privateKey must be ed25519.PrivateKey belonging to the parent's subject.
+// keyID is the DID key reference for the JWS kid header.
+func DeriveEnvelope(parent *Token, childPayload *Payload, privateKey crypto.PrivateKey, keyID string) (string, error) {
+	if parent == nil {
+		return "", fmt.Errorf("parent token is required")
+	}
+	if childPayload == nil {
+		return "", fmt.Errorf("child payload is required")
+	}
+
+	// Set parent authority hash
+	hash := ComputeHash(parent.Raw)
+	childPayload.ParentAuthorityHash = &hash
+
+	// Check that parent allows further delegation
+	if parent.Payload.DelegationDepthRemaining <= 0 {
+		return "", NewError(ErrCodeDepthExceeded,
+			"parent envelope has no remaining delegation depth")
+	}
+
+	// Validate narrowing before signing
+	if err := ValidateNarrowing(parent.Payload, childPayload); err != nil {
+		return "", fmt.Errorf("narrowing validation failed: %w", err)
+	}
+
+	return SignEnvelope(childPayload, privateKey, keyID)
+}
+
+// ValidateChainIntegrity checks the structural integrity of a delegation chain.
+// This validates hash links, DID continuity, narrowing rules, and TxnID consistency.
+// It does NOT verify signatures or badges — use Verifier.VerifyChain for full verification.
+func ValidateChainIntegrity(chain Chain) error {
+	if len(chain) == 0 {
+		return NewError(ErrCodeMalformed, "chain is empty")
+	}
+
+	// First element must be a root envelope
+	root := chain[0]
+	if !root.Payload.IsRoot() {
+		return NewError(ErrCodeChainBroken, "first envelope in chain must be a root (parent_authority_hash == nil)")
+	}
+
+	txnID := root.Payload.TxnID
+
+	for i := 1; i < len(chain); i++ {
+		prev := chain[i-1]
+		curr := chain[i]
+
+		// TxnID consistency
+		if curr.Payload.TxnID != txnID {
+			return NewError(ErrCodeChainBroken,
+				fmt.Sprintf("envelope %d has txn_id %q, expected %q", i, curr.Payload.TxnID, txnID))
+		}
+
+		// Hash link: curr.parent_authority_hash must equal SHA-256(prev.Raw)
+		expectedHash := ComputeHash(prev.Raw)
+		if curr.Payload.ParentAuthorityHash == nil {
+			return NewError(ErrCodeChainBroken,
+				fmt.Sprintf("envelope %d has nil parent_authority_hash (expected %s)", i, expectedHash))
+		}
+		if *curr.Payload.ParentAuthorityHash != expectedHash {
+			return NewError(ErrCodeChainBroken,
+				fmt.Sprintf("envelope %d has parent_authority_hash %q, expected %q",
+					i, *curr.Payload.ParentAuthorityHash, expectedHash))
+		}
+
+		// Monotonic narrowing (includes DID chain check)
+		if err := ValidateNarrowing(prev.Payload, curr.Payload); err != nil {
+			return WrapError(ErrCodeChainBroken,
+				fmt.Sprintf("narrowing violation at chain position %d", i), err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/envelope/chain_test.go
+++ b/pkg/envelope/chain_test.go
@@ -1,0 +1,234 @@
+package envelope_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/capiscio/capiscio-core/v2/pkg/did"
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func buildChain(t *testing.T, depth int) (envelope.Chain, []ed25519.PrivateKey, []ed25519.PublicKey) {
+	t.Helper()
+
+	// Generate keys for depth+1 participants (root issuer + depth subjects)
+	keys := make([]ed25519.PrivateKey, depth+1)
+	pubs := make([]ed25519.PublicKey, depth+1)
+	for i := range keys {
+		pub, priv, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		keys[i] = priv
+		pubs[i] = pub
+	}
+
+	dids := make([]string, len(pubs))
+	for i, pub := range pubs {
+		dids[i] = did.NewKeyDID(pub)
+	}
+
+	now := time.Now()
+	txnID := uuid.New().String()
+
+	// Root envelope
+	rootPayload := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                dids[0],
+		SubjectDID:               dids[1],
+		TxnID:                    txnID,
+		CapabilityClass:          "tools.database",
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: depth,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(1 * time.Hour).Unix(),
+		IssuerBadgeJTI:           uuid.New().String(),
+	}
+
+	rootJWS, err := envelope.SignEnvelope(rootPayload, keys[0], dids[0]+"#key-1")
+	require.NoError(t, err)
+
+	rootToken, err := envelope.ParseToken(rootJWS)
+	require.NoError(t, err)
+
+	chain := envelope.Chain{rootToken}
+
+	// Derived envelopes
+	for i := 1; i < depth; i++ {
+		parent := chain[i-1]
+		childPayload := &envelope.Payload{
+			EnvelopeID:               uuid.New().String(),
+			IssuerDID:                dids[i],
+			SubjectDID:               dids[i+1],
+			TxnID:                    txnID,
+			CapabilityClass:          "tools.database.read",
+			Constraints:              map[string]any{},
+			DelegationDepthRemaining: depth - i,
+			IssuedAt:                 now.Unix(),
+			ExpiresAt:                now.Add(30 * time.Minute).Unix(),
+			IssuerBadgeJTI:           uuid.New().String(),
+			SubjectBadgeJTI:          ptrStr(uuid.New().String()),
+		}
+
+		childJWS, err := envelope.DeriveEnvelope(parent, childPayload, keys[i], dids[i]+"#key-1")
+		require.NoError(t, err)
+
+		childToken, err := envelope.ParseToken(childJWS)
+		require.NoError(t, err)
+
+		chain = append(chain, childToken)
+	}
+
+	return chain, keys, pubs
+}
+
+func ptrStr(s string) *string { return &s }
+
+func TestChain_ValidThreeHop(t *testing.T) {
+	chain, _, _ := buildChain(t, 3)
+	require.Len(t, chain, 3)
+
+	err := envelope.ValidateChainIntegrity(chain)
+	require.NoError(t, err)
+}
+
+func TestChain_SingleRoot(t *testing.T) {
+	chain, _, _ := buildChain(t, 1)
+	require.Len(t, chain, 1)
+
+	err := envelope.ValidateChainIntegrity(chain)
+	require.NoError(t, err)
+}
+
+func TestChain_EmptyChainRejected(t *testing.T) {
+	err := envelope.ValidateChainIntegrity(envelope.Chain{})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "empty")
+}
+
+func TestChain_TamperedHashLink(t *testing.T) {
+	chain, _, _ := buildChain(t, 3)
+
+	// Tamper with the hash link in the second envelope
+	chain[1].Payload.ParentAuthorityHash = ptrStr("0000000000000000000000000000000000000000000000000000000000000000")
+
+	err := envelope.ValidateChainIntegrity(chain)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "CHAIN_BROKEN")
+}
+
+func TestChain_NonRootFirst(t *testing.T) {
+	chain, _, _ := buildChain(t, 3)
+
+	// Remove the root, making the chain start with a non-root envelope
+	invalidChain := chain[1:]
+
+	err := envelope.ValidateChainIntegrity(invalidChain)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "root")
+}
+
+func TestChain_TxnIDMismatch(t *testing.T) {
+	chain, _, _ := buildChain(t, 3)
+
+	// Change txn_id on the last envelope
+	chain[2].Payload.TxnID = "wrong-txn-id"
+
+	err := envelope.ValidateChainIntegrity(chain)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "txn_id")
+}
+
+func TestDeriveEnvelope_DepthExceeded(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, subPriv, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	now := time.Now()
+	rootPayload := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                issuerDID,
+		SubjectDID:               subjectDID,
+		TxnID:                    uuid.New().String(),
+		CapabilityClass:          "tools",
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: 0, // no further delegation allowed
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(time.Hour).Unix(),
+		IssuerBadgeJTI:           uuid.New().String(),
+	}
+
+	rootJWS, err := envelope.SignEnvelope(rootPayload, priv, issuerDID+"#key-1")
+	require.NoError(t, err)
+
+	rootToken, err := envelope.ParseToken(rootJWS)
+	require.NoError(t, err)
+
+	// Try to derive from a depth-0 envelope
+	nextPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	childPayload := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                subjectDID,
+		SubjectDID:               testDID(t, nextPub),
+		TxnID:                    rootPayload.TxnID,
+		CapabilityClass:          "tools",
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: 0,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(30 * time.Minute).Unix(),
+		IssuerBadgeJTI:           uuid.New().String(),
+	}
+
+	_, err = envelope.DeriveEnvelope(rootToken, childPayload, subPriv, subjectDID+"#key-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "DEPTH_EXCEEDED")
+}
+
+func TestDeriveEnvelope_NarrowingViolation(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, subPriv, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	now := time.Now()
+	rootPayload := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                issuerDID,
+		SubjectDID:               subjectDID,
+		TxnID:                    uuid.New().String(),
+		CapabilityClass:          "tools.database.read",
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: 3,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(time.Hour).Unix(),
+		IssuerBadgeJTI:           uuid.New().String(),
+	}
+
+	rootJWS, err := envelope.SignEnvelope(rootPayload, priv, issuerDID+"#key-1")
+	require.NoError(t, err)
+	rootToken, err := envelope.ParseToken(rootJWS)
+	require.NoError(t, err)
+
+	// Try to derive with broader capability
+	nextPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	childPayload := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                subjectDID,
+		SubjectDID:               testDID(t, nextPub),
+		TxnID:                    rootPayload.TxnID,
+		CapabilityClass:          "tools.database", // broader — should fail
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: 2,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(30 * time.Minute).Unix(),
+		IssuerBadgeJTI:           uuid.New().String(),
+	}
+
+	_, err = envelope.DeriveEnvelope(rootToken, childPayload, subPriv, subjectDID+"#key-1")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "NARROWING")
+}

--- a/pkg/envelope/enforcement.go
+++ b/pkg/envelope/enforcement.go
@@ -1,0 +1,60 @@
+package envelope
+
+import "fmt"
+
+// EnforcementMode represents the enforcement strictness level per RFC-008 §10.
+type EnforcementMode int
+
+const (
+	// EMObserve logs verification results but never blocks requests.
+	EMObserve EnforcementMode = iota
+
+	// EMGuard blocks on cryptographic failures but only logs PDP denials.
+	EMGuard
+
+	// EMDelegate blocks on crypto failures and PDP denials; logs obligation failures.
+	EMDelegate
+
+	// EMStrict blocks on all failures including obligation enforcement.
+	EMStrict
+)
+
+var modeStrings = map[EnforcementMode]string{
+	EMObserve:  "EM-OBSERVE",
+	EMGuard:    "EM-GUARD",
+	EMDelegate: "EM-DELEGATE",
+	EMStrict:   "EM-STRICT",
+}
+
+var stringModes = map[string]EnforcementMode{
+	"EM-OBSERVE":  EMObserve,
+	"EM-GUARD":    EMGuard,
+	"EM-DELEGATE": EMDelegate,
+	"EM-STRICT":   EMStrict,
+}
+
+// ParseEnforcementMode converts a string to an EnforcementMode.
+func ParseEnforcementMode(s string) (EnforcementMode, error) {
+	if m, ok := stringModes[s]; ok {
+		return m, nil
+	}
+	return 0, NewError(ErrCodeMalformed, fmt.Sprintf("invalid enforcement mode: %q", s))
+}
+
+// String returns the RFC-008 string representation.
+func (m EnforcementMode) String() string {
+	if s, ok := modeStrings[m]; ok {
+		return s
+	}
+	return fmt.Sprintf("EnforcementMode(%d)", int(m))
+}
+
+// Escalate returns the stricter of configured and minimum modes.
+// Per RFC-008 §10.5: if the envelope sets a minimum that exceeds the PEP's
+// configured mode, the PEP must escalate to the minimum for that request.
+func Escalate(configured, minimum EnforcementMode) EnforcementMode {
+	if minimum > configured {
+		return minimum
+	}
+	return configured
+}

--- a/pkg/envelope/enforcement_test.go
+++ b/pkg/envelope/enforcement_test.go
@@ -1,0 +1,66 @@
+package envelope_test
+
+import (
+	"testing"
+
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseEnforcementMode(t *testing.T) {
+	tests := []struct {
+		input string
+		want  envelope.EnforcementMode
+		err   bool
+	}{
+		{"EM-OBSERVE", envelope.EMObserve, false},
+		{"EM-GUARD", envelope.EMGuard, false},
+		{"EM-DELEGATE", envelope.EMDelegate, false},
+		{"EM-STRICT", envelope.EMStrict, false},
+		{"INVALID", 0, true},
+		{"em-observe", 0, true}, // case-sensitive
+		{"", 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := envelope.ParseEnforcementMode(tt.input)
+			if tt.err {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, tt.want, got)
+			}
+		})
+	}
+}
+
+func TestEnforcementMode_String(t *testing.T) {
+	assert.Equal(t, "EM-OBSERVE", envelope.EMObserve.String())
+	assert.Equal(t, "EM-GUARD", envelope.EMGuard.String())
+	assert.Equal(t, "EM-DELEGATE", envelope.EMDelegate.String())
+	assert.Equal(t, "EM-STRICT", envelope.EMStrict.String())
+}
+
+func TestEscalate(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured envelope.EnforcementMode
+		minimum    envelope.EnforcementMode
+		want       envelope.EnforcementMode
+	}{
+		{"minimum higher", envelope.EMObserve, envelope.EMGuard, envelope.EMGuard},
+		{"configured higher", envelope.EMStrict, envelope.EMGuard, envelope.EMStrict},
+		{"same level", envelope.EMDelegate, envelope.EMDelegate, envelope.EMDelegate},
+		{"observe + strict", envelope.EMObserve, envelope.EMStrict, envelope.EMStrict},
+		{"strict + observe", envelope.EMStrict, envelope.EMObserve, envelope.EMStrict},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := envelope.Escalate(tt.configured, tt.minimum)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/envelope/envelope.go
+++ b/pkg/envelope/envelope.go
@@ -175,11 +175,6 @@ func ParseToken(jwsCompact string) (*Token, error) {
 	}, nil
 }
 
-// ptr returns a pointer to a string value.
-func ptr(s string) *string {
-	return &s
-}
-
 // String returns a human-readable summary of the envelope payload.
 func (p *Payload) String() string {
 	var b strings.Builder

--- a/pkg/envelope/envelope.go
+++ b/pkg/envelope/envelope.go
@@ -1,0 +1,197 @@
+// Package envelope implements RFC-008 Delegated Authority Envelopes.
+//
+// Authority Envelopes are signed JWS tokens that encode delegation of
+// capabilities between agents. Envelopes form chains linked by
+// parent_authority_hash, with monotonic narrowing enforced across four
+// dimensions: capability class, temporal bounds, delegation depth, and
+// constraints.
+package envelope
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+const (
+	// HeaderType is the JWS typ header value for Authority Envelopes.
+	HeaderType = "capiscio-authority-envelope+jws"
+
+	// MaxPayloadSize is the recommended maximum payload size (8 KB).
+	MaxPayloadSize = 8192
+)
+
+// Payload is the Authority Envelope JWT claims payload per RFC-008 §5.4.
+type Payload struct {
+	// EnvelopeID is a unique identifier for this delegation grant (UUID v7).
+	EnvelopeID string `json:"envelope_id"`
+
+	// IssuerDID is the DID of the authority granter.
+	IssuerDID string `json:"issuer_did"`
+
+	// SubjectDID is the DID of the authority receiver.
+	SubjectDID string `json:"subject_did"`
+
+	// TxnID is the RFC-004 transaction identifier.
+	TxnID string `json:"txn_id"`
+
+	// ParentAuthorityHash is the SHA-256 hex hash of the parent envelope's JWS.
+	// nil for root envelopes.
+	ParentAuthorityHash *string `json:"parent_authority_hash"`
+
+	// CapabilityClass is the dot-delimited capability namespace (e.g. "tools.database.read").
+	CapabilityClass string `json:"capability_class"`
+
+	// Constraints is an opaque key-value object interpreted by the PDP.
+	Constraints map[string]any `json:"constraints"`
+
+	// DelegationDepthRemaining is the remaining delegation hops (≥0).
+	// MUST be decremented by ≥1 in each derived envelope.
+	DelegationDepthRemaining int `json:"delegation_depth_remaining"`
+
+	// EnforcementModeMin is the minimum enforcement mode the issuer requires.
+	// nil means no issuer minimum.
+	EnforcementModeMin *string `json:"enforcement_mode_min"`
+
+	// IssuedAt is the Unix timestamp (seconds) of creation.
+	IssuedAt int64 `json:"issued_at"`
+
+	// ExpiresAt is the Unix timestamp (seconds) of expiration.
+	ExpiresAt int64 `json:"expires_at"`
+
+	// IssuerBadgeJTI is the jti of the issuer's current RFC-002 Trust Badge.
+	IssuerBadgeJTI string `json:"issuer_badge_jti"`
+
+	// SubjectBadgeJTI is the jti of the subject's current RFC-002 Trust Badge.
+	// nil for root envelopes when subject has no badge session yet.
+	SubjectBadgeJTI *string `json:"subject_badge_jti"`
+}
+
+// Token wraps a parsed envelope with its raw JWS string.
+type Token struct {
+	// Raw is the JWS Compact Serialization string.
+	Raw string
+
+	// Payload is the decoded envelope payload.
+	Payload *Payload
+}
+
+// ComputeHash returns the SHA-256 hex-lowercase hash of a JWS compact string.
+// Used as parent_authority_hash for derived envelopes (RFC-008 §6.3).
+func ComputeHash(jwsCompact string) string {
+	h := sha256.Sum256([]byte(jwsCompact))
+	return hex.EncodeToString(h[:])
+}
+
+// Validate checks that the payload has all required fields and valid values.
+func (p *Payload) Validate() error {
+	if p.EnvelopeID == "" {
+		return NewError(ErrCodeMalformed, "envelope_id is required")
+	}
+	if p.IssuerDID == "" {
+		return NewError(ErrCodeMalformed, "issuer_did is required")
+	}
+	if p.SubjectDID == "" {
+		return NewError(ErrCodeMalformed, "subject_did is required")
+	}
+	if p.TxnID == "" {
+		return NewError(ErrCodeMalformed, "txn_id is required")
+	}
+	if err := ValidateCapabilityClass(p.CapabilityClass); err != nil {
+		return err
+	}
+	if p.Constraints == nil {
+		return NewError(ErrCodeMalformed, "constraints is required (use empty object)")
+	}
+	if p.DelegationDepthRemaining < 0 {
+		return NewError(ErrCodeMalformed, "delegation_depth_remaining must be >= 0")
+	}
+	if p.EnforcementModeMin != nil {
+		if _, err := ParseEnforcementMode(*p.EnforcementModeMin); err != nil {
+			return err
+		}
+	}
+	if p.IssuedAt <= 0 {
+		return NewError(ErrCodeMalformed, "issued_at is required")
+	}
+	if p.ExpiresAt <= 0 {
+		return NewError(ErrCodeMalformed, "expires_at is required")
+	}
+	if p.ExpiresAt <= p.IssuedAt {
+		return NewError(ErrCodeMalformed, "expires_at must be after issued_at")
+	}
+	if p.IssuerBadgeJTI == "" {
+		return NewError(ErrCodeMalformed, "issuer_badge_jti is required")
+	}
+	return nil
+}
+
+// IsRoot returns true if this is a root envelope (no parent).
+func (p *Payload) IsRoot() bool {
+	return p.ParentAuthorityHash == nil
+}
+
+// ParseToken parses a JWS compact string into a Token without verifying the signature.
+// This is useful for inspection. Use Verifier.VerifyEnvelope for full verification.
+func ParseToken(jwsCompact string) (*Token, error) {
+	jws, err := jose.ParseSigned(jwsCompact, []jose.SignatureAlgorithm{jose.EdDSA, jose.ES256, jose.ES384})
+	if err != nil {
+		return nil, NewError(ErrCodeMalformed, fmt.Sprintf("failed to parse JWS: %v", err))
+	}
+
+	// Check typ header
+	headers := jws.Signatures
+	if len(headers) == 0 {
+		return nil, NewError(ErrCodeMalformed, "no signatures found")
+	}
+	typ := ""
+	if t, ok := headers[0].Protected.ExtraHeaders["typ"].(string); ok {
+		typ = t
+	} else if t, ok := headers[0].Protected.ExtraHeaders[jose.HeaderType].(string); ok {
+		typ = t
+	}
+	if typ != HeaderType {
+		return nil, NewError(ErrCodeMalformed, fmt.Sprintf("invalid typ header: expected %q, got %q", HeaderType, typ))
+	}
+
+	// Extract unverified payload
+	payloadBytes := jws.UnsafePayloadWithoutVerification()
+	if len(payloadBytes) > MaxPayloadSize {
+		return nil, NewError(ErrCodePayloadTooLarge, fmt.Sprintf("payload size %d exceeds maximum %d", len(payloadBytes), MaxPayloadSize))
+	}
+
+	var payload Payload
+	if err := json.Unmarshal(payloadBytes, &payload); err != nil {
+		return nil, NewError(ErrCodeMalformed, fmt.Sprintf("failed to unmarshal payload: %v", err))
+	}
+
+	return &Token{
+		Raw:     jwsCompact,
+		Payload: &payload,
+	}, nil
+}
+
+// ptr returns a pointer to a string value.
+func ptr(s string) *string {
+	return &s
+}
+
+// String returns a human-readable summary of the envelope payload.
+func (p *Payload) String() string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "Envelope %s\n", p.EnvelopeID)
+	fmt.Fprintf(&b, "  Issuer:     %s\n", p.IssuerDID)
+	fmt.Fprintf(&b, "  Subject:    %s\n", p.SubjectDID)
+	fmt.Fprintf(&b, "  Capability: %s\n", p.CapabilityClass)
+	fmt.Fprintf(&b, "  Depth:      %d\n", p.DelegationDepthRemaining)
+	if p.ParentAuthorityHash != nil {
+		fmt.Fprintf(&b, "  Parent:     %s\n", *p.ParentAuthorityHash)
+	} else {
+		fmt.Fprintf(&b, "  Parent:     (root)\n")
+	}
+	return b.String()
+}

--- a/pkg/envelope/envelope_test.go
+++ b/pkg/envelope/envelope_test.go
@@ -1,0 +1,239 @@
+package envelope_test
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/capiscio/capiscio-core/v2/pkg/did"
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func generateTestKey(t *testing.T) (ed25519.PublicKey, ed25519.PrivateKey) {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	return pub, priv
+}
+
+func testDID(t *testing.T, pub ed25519.PublicKey) string {
+	t.Helper()
+	return did.NewKeyDID(pub)
+}
+
+func testPayload(t *testing.T, issuerDID, subjectDID string) *envelope.Payload {
+	t.Helper()
+	now := time.Now()
+	return &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                issuerDID,
+		SubjectDID:               subjectDID,
+		TxnID:                    uuid.New().String(),
+		ParentAuthorityHash:      nil,
+		CapabilityClass:          "tools.database.read",
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: 5,
+		EnforcementModeMin:       nil,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(1 * time.Hour).Unix(),
+		IssuerBadgeJTI:           uuid.New().String(),
+		SubjectBadgeJTI:          nil,
+	}
+}
+
+func TestSignEnvelope_RoundTrip(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	payload := testPayload(t, issuerDID, subjectDID)
+
+	// Sign
+	token, err := envelope.SignEnvelope(payload, priv, issuerDID+"#key-1")
+	require.NoError(t, err)
+	assert.NotEmpty(t, token)
+
+	// Parse back
+	parsed, err := envelope.ParseToken(token)
+	require.NoError(t, err)
+	assert.Equal(t, payload.EnvelopeID, parsed.Payload.EnvelopeID)
+	assert.Equal(t, payload.IssuerDID, parsed.Payload.IssuerDID)
+	assert.Equal(t, payload.SubjectDID, parsed.Payload.SubjectDID)
+	assert.Equal(t, payload.TxnID, parsed.Payload.TxnID)
+	assert.Equal(t, payload.CapabilityClass, parsed.Payload.CapabilityClass)
+	assert.Equal(t, payload.DelegationDepthRemaining, parsed.Payload.DelegationDepthRemaining)
+	assert.Equal(t, payload.IssuedAt, parsed.Payload.IssuedAt)
+	assert.Equal(t, payload.ExpiresAt, parsed.Payload.ExpiresAt)
+	assert.Equal(t, payload.IssuerBadgeJTI, parsed.Payload.IssuerBadgeJTI)
+	assert.Nil(t, parsed.Payload.ParentAuthorityHash)
+	assert.Nil(t, parsed.Payload.SubjectBadgeJTI)
+	assert.True(t, parsed.Payload.IsRoot())
+}
+
+func TestSignEnvelope_WithOptionalFields(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	now := time.Now()
+	emStr := "EM-STRICT"
+	subBadgeJTI := uuid.New().String()
+	parentHash := "abc123def456"
+
+	payload := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                issuerDID,
+		SubjectDID:               subjectDID,
+		TxnID:                    uuid.New().String(),
+		ParentAuthorityHash:      &parentHash,
+		CapabilityClass:          "tools.database",
+		Constraints:              map[string]any{"max_rows": float64(100)},
+		DelegationDepthRemaining: 3,
+		EnforcementModeMin:       &emStr,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(30 * time.Minute).Unix(),
+		IssuerBadgeJTI:           uuid.New().String(),
+		SubjectBadgeJTI:          &subBadgeJTI,
+	}
+
+	token, err := envelope.SignEnvelope(payload, priv, issuerDID+"#key-1")
+	require.NoError(t, err)
+
+	parsed, err := envelope.ParseToken(token)
+	require.NoError(t, err)
+	assert.Equal(t, &parentHash, parsed.Payload.ParentAuthorityHash)
+	assert.Equal(t, &emStr, parsed.Payload.EnforcementModeMin)
+	assert.Equal(t, &subBadgeJTI, parsed.Payload.SubjectBadgeJTI)
+	assert.False(t, parsed.Payload.IsRoot())
+	assert.Equal(t, float64(100), parsed.Payload.Constraints["max_rows"])
+}
+
+func TestSignEnvelope_InvalidPayload(t *testing.T) {
+	_, priv := generateTestKey(t)
+
+	tests := []struct {
+		name    string
+		modify  func(*envelope.Payload)
+		wantErr string
+	}{
+		{
+			name:    "missing envelope_id",
+			modify:  func(p *envelope.Payload) { p.EnvelopeID = "" },
+			wantErr: "envelope_id",
+		},
+		{
+			name:    "missing issuer_did",
+			modify:  func(p *envelope.Payload) { p.IssuerDID = "" },
+			wantErr: "issuer_did",
+		},
+		{
+			name:    "missing subject_did",
+			modify:  func(p *envelope.Payload) { p.SubjectDID = "" },
+			wantErr: "subject_did",
+		},
+		{
+			name:    "missing txn_id",
+			modify:  func(p *envelope.Payload) { p.TxnID = "" },
+			wantErr: "txn_id",
+		},
+		{
+			name:    "invalid capability class",
+			modify:  func(p *envelope.Payload) { p.CapabilityClass = "Invalid.Class" },
+			wantErr: "CAPABILITY",
+		},
+		{
+			name:    "nil constraints",
+			modify:  func(p *envelope.Payload) { p.Constraints = nil },
+			wantErr: "constraints",
+		},
+		{
+			name:    "negative depth",
+			modify:  func(p *envelope.Payload) { p.DelegationDepthRemaining = -1 },
+			wantErr: "delegation_depth_remaining",
+		},
+		{
+			name:    "invalid enforcement mode",
+			modify:  func(p *envelope.Payload) { s := "INVALID"; p.EnforcementModeMin = &s },
+			wantErr: "enforcement mode",
+		},
+		{
+			name:    "expires_at before issued_at",
+			modify:  func(p *envelope.Payload) { p.ExpiresAt = p.IssuedAt - 1 },
+			wantErr: "expires_at",
+		},
+		{
+			name:    "missing issuer_badge_jti",
+			modify:  func(p *envelope.Payload) { p.IssuerBadgeJTI = "" },
+			wantErr: "issuer_badge_jti",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pub, _ := generateTestKey(t)
+			payload := testPayload(t, testDID(t, pub), "did:key:z6MkSubject")
+			tt.modify(payload)
+			_, err := envelope.SignEnvelope(payload, priv, "did:key:test#key-1")
+			require.Error(t, err)
+			assert.Contains(t, err.Error(), tt.wantErr)
+		})
+	}
+}
+
+func TestComputeHash(t *testing.T) {
+	hash := envelope.ComputeHash("test-jws-string")
+	assert.Len(t, hash, 64) // SHA-256 hex is 64 chars
+	assert.Equal(t, strings.ToLower(hash), hash) // lowercase
+
+	// Same input = same output
+	hash2 := envelope.ComputeHash("test-jws-string")
+	assert.Equal(t, hash, hash2)
+
+	// Different input = different output
+	hash3 := envelope.ComputeHash("different-jws-string")
+	assert.NotEqual(t, hash, hash3)
+}
+
+func TestParseToken_InvalidJWS(t *testing.T) {
+	_, err := envelope.ParseToken("not-a-valid-jws")
+	require.Error(t, err)
+
+	var envErr *envelope.Error
+	require.ErrorAs(t, err, &envErr)
+	assert.Equal(t, "ENVELOPE_MALFORMED", envErr.Code)
+}
+
+func TestPayload_JSONMarshal(t *testing.T) {
+	now := time.Now()
+	p := &envelope.Payload{
+		EnvelopeID:               "test-id",
+		IssuerDID:                "did:key:issuer",
+		SubjectDID:               "did:key:subject",
+		TxnID:                    "txn-1",
+		CapabilityClass:          "tools",
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: 3,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(time.Hour).Unix(),
+		IssuerBadgeJTI:           "badge-1",
+	}
+
+	data, err := json.Marshal(p)
+	require.NoError(t, err)
+
+	var decoded envelope.Payload
+	err = json.Unmarshal(data, &decoded)
+	require.NoError(t, err)
+	assert.Equal(t, p.EnvelopeID, decoded.EnvelopeID)
+	assert.Nil(t, decoded.ParentAuthorityHash)
+	assert.Nil(t, decoded.SubjectBadgeJTI)
+	assert.Nil(t, decoded.EnforcementModeMin)
+}

--- a/pkg/envelope/errors.go
+++ b/pkg/envelope/errors.go
@@ -1,0 +1,96 @@
+package envelope
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Error codes for Authority Envelope operations per RFC-008.
+const (
+	// ErrCodeMalformed indicates the JWS structure or payload is invalid.
+	ErrCodeMalformed = "ENVELOPE_MALFORMED"
+
+	// ErrCodeSignatureInvalid indicates JWS signature verification failed.
+	ErrCodeSignatureInvalid = "ENVELOPE_SIGNATURE_INVALID"
+
+	// ErrCodeExpired indicates the envelope has expired (now >= expires_at).
+	ErrCodeExpired = "ENVELOPE_EXPIRED"
+
+	// ErrCodeNotYetValid indicates issued_at is in the future.
+	ErrCodeNotYetValid = "ENVELOPE_NOT_YET_VALID"
+
+	// ErrCodeAlgorithmForbidden indicates a forbidden algorithm (none, HMAC).
+	ErrCodeAlgorithmForbidden = "ENVELOPE_ALGORITHM_FORBIDDEN"
+
+	// ErrCodeBadgeBindingFailed indicates issuer/subject badge JTI mismatch.
+	ErrCodeBadgeBindingFailed = "ENVELOPE_BADGE_BINDING_FAILED"
+
+	// ErrCodeChainBroken indicates a chain integrity failure (hash or DID mismatch).
+	ErrCodeChainBroken = "ENVELOPE_CHAIN_BROKEN"
+
+	// ErrCodeNarrowingViolation indicates monotonic narrowing was violated.
+	ErrCodeNarrowingViolation = "ENVELOPE_NARROWING_VIOLATION"
+
+	// ErrCodeDepthExceeded indicates an attempt to delegate at depth 0.
+	ErrCodeDepthExceeded = "ENVELOPE_DEPTH_EXCEEDED"
+
+	// ErrCodeKeyNotBound indicates the signing key is not bound to the issuer DID.
+	ErrCodeKeyNotBound = "ENVELOPE_KEY_NOT_BOUND"
+
+	// ErrCodeCapabilityInvalid indicates an invalid capability class format.
+	ErrCodeCapabilityInvalid = "ENVELOPE_CAPABILITY_INVALID"
+
+	// ErrCodePayloadTooLarge indicates the envelope payload exceeds the maximum size.
+	ErrCodePayloadTooLarge = "ENVELOPE_PAYLOAD_TOO_LARGE"
+)
+
+// Error represents an envelope operation error with an RFC-008 error code.
+type Error struct {
+	// Code is one of the ENVELOPE_* error codes.
+	Code string
+
+	// Message is a human-readable description.
+	Message string
+
+	// Cause is the underlying error, if any.
+	Cause error
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %s: %v", e.Code, e.Message, e.Cause)
+	}
+	return fmt.Sprintf("%s: %s", e.Code, e.Message)
+}
+
+// Unwrap returns the underlying cause for errors.Is/errors.As.
+func (e *Error) Unwrap() error {
+	return e.Cause
+}
+
+// Is checks if the error matches a target error code.
+func (e *Error) Is(target error) bool {
+	var t *Error
+	if errors.As(target, &t) {
+		return e.Code == t.Code
+	}
+	return false
+}
+
+// NewError creates a new Error with the given code and message.
+func NewError(code, message string) *Error {
+	return &Error{
+		Code:    code,
+		Message: message,
+	}
+}
+
+// WrapError creates a new Error that wraps an underlying error.
+func WrapError(code, message string, cause error) *Error {
+	return &Error{
+		Code:    code,
+		Message: message,
+		Cause:   cause,
+	}
+}

--- a/pkg/envelope/issuer.go
+++ b/pkg/envelope/issuer.go
@@ -1,0 +1,44 @@
+package envelope
+
+import (
+	"crypto"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-jose/go-jose/v4"
+)
+
+// SignEnvelope creates a signed Authority Envelope JWS token.
+// privateKey must be an ed25519.PrivateKey.
+// keyID is the DID key reference for the JWS kid header (e.g., "did:key:z6Mk...#key-1").
+func SignEnvelope(payload *Payload, privateKey crypto.PrivateKey, keyID string) (string, error) {
+	if err := payload.Validate(); err != nil {
+		return "", fmt.Errorf("invalid payload: %w", err)
+	}
+
+	opts := &jose.SignerOptions{}
+	opts.WithType(HeaderType)
+	opts.WithHeader("kid", keyID)
+
+	signer, err := jose.NewSigner(jose.SigningKey{Algorithm: jose.EdDSA, Key: privateKey}, opts)
+	if err != nil {
+		return "", fmt.Errorf("failed to create signer: %w", err)
+	}
+
+	payloadBytes, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("failed to marshal payload: %w", err)
+	}
+
+	jwsObj, err := signer.Sign(payloadBytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign payload: %w", err)
+	}
+
+	token, err := jwsObj.CompactSerialize()
+	if err != nil {
+		return "", fmt.Errorf("failed to serialize JWS: %w", err)
+	}
+
+	return token, nil
+}

--- a/pkg/envelope/narrowing.go
+++ b/pkg/envelope/narrowing.go
@@ -1,0 +1,51 @@
+package envelope
+
+import "fmt"
+
+// ValidateNarrowing checks all PEP-enforceable monotonic narrowing dimensions
+// between a parent and child envelope per RFC-008 §8.
+//
+// This validates:
+//   - Capability class (§8.2): child must equal or narrow parent
+//   - Temporal bounds (§8.3): child must not exceed parent's temporal window
+//   - Delegation depth (§8.4): child must strictly decrement depth
+//   - DID chain (§6.3): child issuer must be parent subject
+//
+// Constraint subset validation (§8.5) is NOT checked here — that is the PDP's
+// responsibility per the RFC.
+func ValidateNarrowing(parent, child *Payload) error {
+	// §6.3: DID chain continuity
+	if child.IssuerDID != parent.SubjectDID {
+		return NewError(ErrCodeChainBroken,
+			fmt.Sprintf("child issuer_did %q does not match parent subject_did %q",
+				child.IssuerDID, parent.SubjectDID))
+	}
+
+	// §8.2: Capability class — child must be same or more specific
+	if !IsWithinScope(child.CapabilityClass, parent.CapabilityClass) {
+		return NewError(ErrCodeNarrowingViolation,
+			fmt.Sprintf("capability class %q is not within scope of parent %q",
+				child.CapabilityClass, parent.CapabilityClass))
+	}
+
+	// §8.3: Temporal bounds — child must not exceed parent's window
+	if child.ExpiresAt > parent.ExpiresAt {
+		return NewError(ErrCodeNarrowingViolation,
+			fmt.Sprintf("child expires_at %d exceeds parent expires_at %d",
+				child.ExpiresAt, parent.ExpiresAt))
+	}
+	if child.IssuedAt < parent.IssuedAt {
+		return NewError(ErrCodeNarrowingViolation,
+			fmt.Sprintf("child issued_at %d precedes parent issued_at %d",
+				child.IssuedAt, parent.IssuedAt))
+	}
+
+	// §8.4: Delegation depth — must be strictly decremented
+	if child.DelegationDepthRemaining >= parent.DelegationDepthRemaining {
+		return NewError(ErrCodeNarrowingViolation,
+			fmt.Sprintf("child depth %d is not less than parent depth %d",
+				child.DelegationDepthRemaining, parent.DelegationDepthRemaining))
+	}
+
+	return nil
+}

--- a/pkg/envelope/narrowing_test.go
+++ b/pkg/envelope/narrowing_test.go
@@ -1,0 +1,130 @@
+package envelope_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidateNarrowing(t *testing.T) {
+	now := time.Now()
+	baseParent := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                "did:key:issuerA",
+		SubjectDID:               "did:key:subjectB",
+		TxnID:                    "txn-1",
+		CapabilityClass:          "tools.database",
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: 5,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(1 * time.Hour).Unix(),
+		IssuerBadgeJTI:           "badge-a",
+	}
+
+	makeChild := func(modify func(*envelope.Payload)) *envelope.Payload {
+		child := &envelope.Payload{
+			EnvelopeID:               uuid.New().String(),
+			IssuerDID:                "did:key:subjectB", // must match parent subject
+			SubjectDID:               "did:key:subjectC",
+			TxnID:                    "txn-1",
+			CapabilityClass:          "tools.database.read", // narrower
+			Constraints:              map[string]any{},
+			DelegationDepthRemaining: 4, // decremented
+			IssuedAt:                 now.Unix(),
+			ExpiresAt:                now.Add(30 * time.Minute).Unix(), // tighter
+			IssuerBadgeJTI:           "badge-b",
+		}
+		if modify != nil {
+			modify(child)
+		}
+		return child
+	}
+
+	tests := []struct {
+		name    string
+		modify  func(*envelope.Payload)
+		wantErr string // "" = no error
+	}{
+		// Valid cases
+		{
+			name:   "valid narrowing — all dimensions tighter",
+			modify: nil,
+		},
+		{
+			name:   "same capability class is valid",
+			modify: func(c *envelope.Payload) { c.CapabilityClass = "tools.database" },
+		},
+		{
+			name: "same temporal bounds valid",
+			modify: func(c *envelope.Payload) {
+				c.IssuedAt = baseParent.IssuedAt
+				c.ExpiresAt = baseParent.ExpiresAt
+			},
+		},
+
+		// Capability class violations
+		{
+			name:    "broader capability rejected",
+			modify:  func(c *envelope.Payload) { c.CapabilityClass = "tools" },
+			wantErr: "NARROWING",
+		},
+		{
+			name:    "unrelated capability rejected",
+			modify:  func(c *envelope.Payload) { c.CapabilityClass = "files.write" },
+			wantErr: "NARROWING",
+		},
+		{
+			name:    "sibling capability rejected",
+			modify:  func(c *envelope.Payload) { c.CapabilityClass = "tools.filesystem" },
+			wantErr: "NARROWING",
+		},
+
+		// Temporal violations
+		{
+			name:    "later expiry rejected",
+			modify:  func(c *envelope.Payload) { c.ExpiresAt = baseParent.ExpiresAt + 1 },
+			wantErr: "NARROWING",
+		},
+		{
+			name:    "earlier issued_at rejected",
+			modify:  func(c *envelope.Payload) { c.IssuedAt = baseParent.IssuedAt - 1 },
+			wantErr: "NARROWING",
+		},
+
+		// Depth violations
+		{
+			name:    "depth not decremented rejected",
+			modify:  func(c *envelope.Payload) { c.DelegationDepthRemaining = 5 },
+			wantErr: "NARROWING",
+		},
+		{
+			name:    "depth increased rejected",
+			modify:  func(c *envelope.Payload) { c.DelegationDepthRemaining = 6 },
+			wantErr: "NARROWING",
+		},
+
+		// DID chain violations
+		{
+			name:    "broken DID chain rejected",
+			modify:  func(c *envelope.Payload) { c.IssuerDID = "did:key:wrongIssuer" },
+			wantErr: "CHAIN_BROKEN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			child := makeChild(tt.modify)
+			err := envelope.ValidateNarrowing(baseParent, child)
+			if tt.wantErr == "" {
+				require.NoError(t, err)
+			} else {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/envelope/verifier.go
+++ b/pkg/envelope/verifier.go
@@ -1,0 +1,335 @@
+package envelope
+
+import (
+	"context"
+	"crypto"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/capiscio/capiscio-core/v2/pkg/badge"
+	"github.com/capiscio/capiscio-core/v2/pkg/did"
+	"github.com/go-jose/go-jose/v4"
+)
+
+// KeyResolver resolves a DID and key ID to a public key.
+// For did:key: extracts the public key from the DID itself (no network call).
+// For did:web: fetches the DID document and extracts the key by fragment.
+type KeyResolver func(ctx context.Context, didStr string, kid string) (crypto.PublicKey, error)
+
+// DefaultKeyResolver resolves did:key identifiers to Ed25519 public keys.
+// It does not support did:web (returns an error for non-did:key identifiers).
+func DefaultKeyResolver(_ context.Context, didStr string, _ string) (crypto.PublicKey, error) {
+	parsed, err := did.Parse(didStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse DID %q: %w", didStr, err)
+	}
+	if !parsed.IsKeyDID() {
+		return nil, fmt.Errorf("DID %q is not a did:key identifier; did:web resolution not yet supported", didStr)
+	}
+	pubKey := parsed.GetPublicKey()
+	if pubKey == nil {
+		return nil, fmt.Errorf("failed to extract public key from DID %q", didStr)
+	}
+	return pubKey, nil
+}
+
+// VerifyOptions configures envelope verification.
+type VerifyOptions struct {
+	// TrustedIssuers restricts which badge issuers are accepted.
+	// Passed through to badge verification.
+	TrustedIssuers []string
+
+	// EnforcementMode is the PEP's configured enforcement mode.
+	EnforcementMode EnforcementMode
+
+	// MaxPayloadSize is the max envelope payload in bytes. Default: 8192.
+	MaxPayloadSize int
+
+	// Now overrides time.Now() for testing.
+	Now func() time.Time
+
+	// SkipBadgeVerification skips badge verification steps.
+	// For testing only — never use in production.
+	SkipBadgeVerification bool
+}
+
+func (o *VerifyOptions) now() time.Time {
+	if o.Now != nil {
+		return o.Now()
+	}
+	return time.Now()
+}
+
+func (o *VerifyOptions) maxPayloadSize() int {
+	if o.MaxPayloadSize > 0 {
+		return o.MaxPayloadSize
+	}
+	return MaxPayloadSize
+}
+
+// VerifyResult contains the outcome of envelope verification.
+type VerifyResult struct {
+	// Payload is the verified envelope payload.
+	Payload *Payload
+
+	// IssuerBadge is the verified issuer badge result (nil if badge verification skipped).
+	IssuerBadge *badge.VerifyResult
+
+	// SubjectBadge is the verified subject badge result (nil for root or if skipped).
+	SubjectBadge *badge.VerifyResult
+
+	// EffectiveMode is the enforcement mode after escalation.
+	EffectiveMode EnforcementMode
+
+	// ChainDepth is 0 for root envelopes, N for the Nth delegation.
+	ChainDepth int
+}
+
+// ChainVerifyResult contains the outcome of chain verification.
+type ChainVerifyResult struct {
+	// Links contains the verification result for each envelope in the chain.
+	Links []*VerifyResult
+
+	// RootCapability is the capability class from the root envelope.
+	RootCapability string
+
+	// LeafCapability is the capability class from the leaf (last) envelope.
+	LeafCapability string
+
+	// TotalDepth is the number of delegation hops in the chain.
+	TotalDepth int
+}
+
+// Verifier verifies Authority Envelopes per RFC-008 §9.2.
+type Verifier struct {
+	// BadgeVerifier verifies trust badges (RFC-002).
+	BadgeVerifier *badge.Verifier
+
+	// KeyResolver resolves DIDs to public keys.
+	KeyResolver KeyResolver
+}
+
+// VerifyEnvelope verifies a single Authority Envelope.
+//
+// It implements the RFC-008 §9.2 verification sequence:
+//  1. Parse and validate envelope structure
+//  2. Verify issuer badge (RFC-002) — if not skipped
+//  3. Resolve signing key from issuer DID
+//  4. Verify JWS signature
+//  5. Check temporal validity
+//  6. Verify badge JTI bindings
+//  7. Apply enforcement mode escalation
+//
+// Steps 5 (invocation evidence, RFC-004) and 9 (PDP query, RFC-005) from the spec
+// are not implemented — those RFCs are not yet available.
+func (v *Verifier) VerifyEnvelope(
+	ctx context.Context,
+	envelopeJWS string,
+	issuerBadgeJWS string,
+	subjectBadgeJWS string,
+	opts VerifyOptions,
+) (*VerifyResult, error) {
+	// Step 1: Parse envelope
+	maxSize := opts.maxPayloadSize()
+	jws, err := jose.ParseSigned(envelopeJWS, []jose.SignatureAlgorithm{jose.EdDSA, jose.ES256, jose.ES384})
+	if err != nil {
+		return nil, NewError(ErrCodeMalformed, fmt.Sprintf("failed to parse JWS: %v", err))
+	}
+
+	// Check typ header
+	if len(jws.Signatures) == 0 {
+		return nil, NewError(ErrCodeMalformed, "no signatures found")
+	}
+	typ := ""
+	if t, ok := jws.Signatures[0].Protected.ExtraHeaders["typ"].(string); ok {
+		typ = t
+	} else if t, ok := jws.Signatures[0].Protected.ExtraHeaders[jose.HeaderType].(string); ok {
+		typ = t
+	}
+	if typ != HeaderType {
+		return nil, NewError(ErrCodeMalformed,
+			fmt.Sprintf("invalid typ header: expected %q, got %q", HeaderType, typ))
+	}
+
+	// Step 2: Verify issuer badge
+	var issuerBadgeResult *badge.VerifyResult
+	if !opts.SkipBadgeVerification && issuerBadgeJWS != "" {
+		if v.BadgeVerifier == nil {
+			return nil, fmt.Errorf("badge verifier is required for badge verification")
+		}
+		badgeOpts := badge.VerifyOptions{
+			TrustedIssuers:       opts.TrustedIssuers,
+			AcceptSelfSigned:     true, // self-signed badges can issue envelopes
+			SkipRevocationCheck:  false,
+			SkipAgentStatusCheck: false,
+		}
+		issuerBadgeResult, err = v.BadgeVerifier.VerifyWithOptions(ctx, issuerBadgeJWS, badgeOpts)
+		if err != nil {
+			return nil, WrapError(ErrCodeBadgeBindingFailed, "issuer badge verification failed", err)
+		}
+	}
+
+	// Step 3: Resolve signing key from issuer DID
+	kid := ""
+	if k, ok := jws.Signatures[0].Protected.ExtraHeaders["kid"].(string); ok {
+		kid = k
+	} else if k, ok := jws.Signatures[0].Protected.ExtraHeaders[jose.HeaderKey("kid")].(string); ok {
+		kid = k
+	}
+
+	// Extract unverified payload to get issuer_did for key resolution
+	unverifiedPayload := jws.UnsafePayloadWithoutVerification()
+	if len(unverifiedPayload) > maxSize {
+		return nil, NewError(ErrCodePayloadTooLarge,
+			fmt.Sprintf("payload size %d exceeds maximum %d", len(unverifiedPayload), maxSize))
+	}
+
+	var unverifiedClaims Payload
+	if err := json.Unmarshal(unverifiedPayload, &unverifiedClaims); err != nil {
+		return nil, NewError(ErrCodeMalformed, fmt.Sprintf("failed to unmarshal payload: %v", err))
+	}
+
+	resolver := v.KeyResolver
+	if resolver == nil {
+		resolver = DefaultKeyResolver
+	}
+
+	pubKey, err := resolver(ctx, unverifiedClaims.IssuerDID, kid)
+	if err != nil {
+		return nil, WrapError(ErrCodeKeyNotBound,
+			fmt.Sprintf("failed to resolve key for DID %q", unverifiedClaims.IssuerDID), err)
+	}
+
+	// Step 4: Verify JWS signature
+	verifiedPayload, err := jws.Verify(pubKey)
+	if err != nil {
+		return nil, NewError(ErrCodeSignatureInvalid, fmt.Sprintf("signature verification failed: %v", err))
+	}
+
+	var payload Payload
+	if err := json.Unmarshal(verifiedPayload, &payload); err != nil {
+		return nil, NewError(ErrCodeMalformed, fmt.Sprintf("failed to unmarshal verified payload: %v", err))
+	}
+
+	if err := payload.Validate(); err != nil {
+		return nil, err
+	}
+
+	// Step 5: Temporal validity
+	now := opts.now()
+	nowUnix := now.Unix()
+	if nowUnix >= payload.ExpiresAt {
+		return nil, NewError(ErrCodeExpired,
+			fmt.Sprintf("envelope expired at %d, current time is %d", payload.ExpiresAt, nowUnix))
+	}
+	if payload.IssuedAt > nowUnix {
+		return nil, NewError(ErrCodeNotYetValid,
+			fmt.Sprintf("envelope issued_at %d is in the future (current time %d)", payload.IssuedAt, nowUnix))
+	}
+
+	// Step 6: Badge JTI binding
+	if issuerBadgeResult != nil {
+		if payload.IssuerBadgeJTI != issuerBadgeResult.Claims.JTI {
+			return nil, NewError(ErrCodeBadgeBindingFailed,
+				fmt.Sprintf("issuer_badge_jti %q does not match presented badge jti %q",
+					payload.IssuerBadgeJTI, issuerBadgeResult.Claims.JTI))
+		}
+	}
+
+	var subjectBadgeResult *badge.VerifyResult
+	if !opts.SkipBadgeVerification && payload.SubjectBadgeJTI != nil && subjectBadgeJWS != "" {
+		if v.BadgeVerifier == nil {
+			return nil, fmt.Errorf("badge verifier is required for subject badge verification")
+		}
+		badgeOpts := badge.VerifyOptions{
+			TrustedIssuers:       opts.TrustedIssuers,
+			AcceptSelfSigned:     true,
+			SkipRevocationCheck:  false,
+			SkipAgentStatusCheck: false,
+		}
+		subjectBadgeResult, err = v.BadgeVerifier.VerifyWithOptions(ctx, subjectBadgeJWS, badgeOpts)
+		if err != nil {
+			return nil, WrapError(ErrCodeBadgeBindingFailed, "subject badge verification failed", err)
+		}
+		if *payload.SubjectBadgeJTI != subjectBadgeResult.Claims.JTI {
+			return nil, NewError(ErrCodeBadgeBindingFailed,
+				fmt.Sprintf("subject_badge_jti %q does not match presented badge jti %q",
+					*payload.SubjectBadgeJTI, subjectBadgeResult.Claims.JTI))
+		}
+	}
+
+	// Step 7: Enforcement mode escalation
+	effectiveMode := opts.EnforcementMode
+	if payload.EnforcementModeMin != nil {
+		minMode, err := ParseEnforcementMode(*payload.EnforcementModeMin)
+		if err != nil {
+			return nil, err
+		}
+		effectiveMode = Escalate(effectiveMode, minMode)
+	}
+
+	return &VerifyResult{
+		Payload:       &payload,
+		IssuerBadge:   issuerBadgeResult,
+		SubjectBadge:  subjectBadgeResult,
+		EffectiveMode: effectiveMode,
+	}, nil
+}
+
+// VerifyChain verifies a full delegation chain of Authority Envelopes.
+// envelopeJWSs must be ordered root→leaf.
+// badgeJWSMap maps DIDs to their current badge JWS strings.
+func (v *Verifier) VerifyChain(
+	ctx context.Context,
+	envelopeJWSs []string,
+	badgeJWSMap map[string]string,
+	opts VerifyOptions,
+) (*ChainVerifyResult, error) {
+	if len(envelopeJWSs) == 0 {
+		return nil, NewError(ErrCodeMalformed, "chain is empty")
+	}
+
+	// First pass: parse all tokens to validate structure
+	tokens := make(Chain, 0, len(envelopeJWSs))
+	for i, jws := range envelopeJWSs {
+		token, err := ParseToken(jws)
+		if err != nil {
+			return nil, WrapError(ErrCodeChainBroken,
+				fmt.Sprintf("failed to parse envelope at position %d", i), err)
+		}
+		tokens = append(tokens, token)
+	}
+
+	// Validate chain structural integrity (hash links, narrowing, DID chain)
+	if err := ValidateChainIntegrity(tokens); err != nil {
+		return nil, err
+	}
+
+	// Verify each envelope individually
+	links := make([]*VerifyResult, 0, len(envelopeJWSs))
+	for i, jwsStr := range envelopeJWSs {
+		payload := tokens[i].Payload
+
+		issuerBadge := badgeJWSMap[payload.IssuerDID]
+		subjectBadge := ""
+		if payload.SubjectBadgeJTI != nil {
+			subjectBadge = badgeJWSMap[payload.SubjectDID]
+		}
+
+		result, err := v.VerifyEnvelope(ctx, jwsStr, issuerBadge, subjectBadge, opts)
+		if err != nil {
+			return nil, WrapError(ErrCodeChainBroken,
+				fmt.Sprintf("verification failed at chain position %d", i), err)
+		}
+		result.ChainDepth = i
+		links = append(links, result)
+	}
+
+	return &ChainVerifyResult{
+		Links:          links,
+		RootCapability: tokens[0].Payload.CapabilityClass,
+		LeafCapability: tokens[len(tokens)-1].Payload.CapabilityClass,
+		TotalDepth:     len(tokens) - 1,
+	}, nil
+}

--- a/pkg/envelope/verifier.go
+++ b/pkg/envelope/verifier.go
@@ -131,13 +131,61 @@ func (v *Verifier) VerifyEnvelope(
 	opts VerifyOptions,
 ) (*VerifyResult, error) {
 	// Step 1: Parse envelope
-	maxSize := opts.maxPayloadSize()
+	jws, err := v.parseEnvelopeJWS(envelopeJWS, opts.maxPayloadSize())
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 2: Verify issuer badge
+	issuerBadgeResult, err := v.verifyBadge(ctx, issuerBadgeJWS, opts)
+	if err != nil {
+		return nil, WrapError(ErrCodeBadgeBindingFailed, "issuer badge verification failed", err)
+	}
+
+	// Steps 3-4: Resolve key and verify signature
+	payload, err := v.resolveAndVerifySignature(ctx, jws, opts.maxPayloadSize())
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 5: Temporal validity
+	if err := v.checkTemporal(payload, opts.now()); err != nil {
+		return nil, err
+	}
+
+	// Step 6: Badge JTI binding (issuer)
+	if issuerBadgeResult != nil && payload.IssuerBadgeJTI != issuerBadgeResult.Claims.JTI {
+		return nil, NewError(ErrCodeBadgeBindingFailed,
+			fmt.Sprintf("issuer_badge_jti %q does not match presented badge jti %q",
+				payload.IssuerBadgeJTI, issuerBadgeResult.Claims.JTI))
+	}
+
+	// Step 6b: Badge JTI binding (subject)
+	subjectBadgeResult, err := v.verifySubjectBadge(ctx, payload, subjectBadgeJWS, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	// Step 7: Enforcement mode escalation
+	effectiveMode, err := v.resolveEnforcementMode(payload, opts.EnforcementMode)
+	if err != nil {
+		return nil, err
+	}
+
+	return &VerifyResult{
+		Payload:       payload,
+		IssuerBadge:   issuerBadgeResult,
+		SubjectBadge:  subjectBadgeResult,
+		EffectiveMode: effectiveMode,
+	}, nil
+}
+
+// parseEnvelopeJWS parses the JWS and validates the typ header.
+func (v *Verifier) parseEnvelopeJWS(envelopeJWS string, maxSize int) (*jose.JSONWebSignature, error) {
 	jws, err := jose.ParseSigned(envelopeJWS, []jose.SignatureAlgorithm{jose.EdDSA, jose.ES256, jose.ES384})
 	if err != nil {
 		return nil, NewError(ErrCodeMalformed, fmt.Sprintf("failed to parse JWS: %v", err))
 	}
-
-	// Check typ header
 	if len(jws.Signatures) == 0 {
 		return nil, NewError(ErrCodeMalformed, "no signatures found")
 	}
@@ -151,26 +199,33 @@ func (v *Verifier) VerifyEnvelope(
 		return nil, NewError(ErrCodeMalformed,
 			fmt.Sprintf("invalid typ header: expected %q, got %q", HeaderType, typ))
 	}
-
-	// Step 2: Verify issuer badge
-	var issuerBadgeResult *badge.VerifyResult
-	if !opts.SkipBadgeVerification && issuerBadgeJWS != "" {
-		if v.BadgeVerifier == nil {
-			return nil, fmt.Errorf("badge verifier is required for badge verification")
-		}
-		badgeOpts := badge.VerifyOptions{
-			TrustedIssuers:       opts.TrustedIssuers,
-			AcceptSelfSigned:     true, // self-signed badges can issue envelopes
-			SkipRevocationCheck:  false,
-			SkipAgentStatusCheck: false,
-		}
-		issuerBadgeResult, err = v.BadgeVerifier.VerifyWithOptions(ctx, issuerBadgeJWS, badgeOpts)
-		if err != nil {
-			return nil, WrapError(ErrCodeBadgeBindingFailed, "issuer badge verification failed", err)
-		}
+	unverifiedPayload := jws.UnsafePayloadWithoutVerification()
+	if len(unverifiedPayload) > maxSize {
+		return nil, NewError(ErrCodePayloadTooLarge,
+			fmt.Sprintf("payload size %d exceeds maximum %d", len(unverifiedPayload), maxSize))
 	}
+	return jws, nil
+}
 
-	// Step 3: Resolve signing key from issuer DID
+// verifyBadge verifies a badge JWS if badge verification is enabled.
+func (v *Verifier) verifyBadge(ctx context.Context, badgeJWS string, opts VerifyOptions) (*badge.VerifyResult, error) {
+	if opts.SkipBadgeVerification || badgeJWS == "" {
+		return nil, nil
+	}
+	if v.BadgeVerifier == nil {
+		return nil, fmt.Errorf("badge verifier is required for badge verification")
+	}
+	badgeOpts := badge.VerifyOptions{
+		TrustedIssuers:       opts.TrustedIssuers,
+		AcceptSelfSigned:     true,
+		SkipRevocationCheck:  false,
+		SkipAgentStatusCheck: false,
+	}
+	return v.BadgeVerifier.VerifyWithOptions(ctx, badgeJWS, badgeOpts)
+}
+
+// resolveAndVerifySignature resolves the signing key and verifies the JWS signature.
+func (v *Verifier) resolveAndVerifySignature(ctx context.Context, jws *jose.JSONWebSignature, maxSize int) (*Payload, error) {
 	kid := ""
 	if k, ok := jws.Signatures[0].Protected.ExtraHeaders["kid"].(string); ok {
 		kid = k
@@ -178,13 +233,7 @@ func (v *Verifier) VerifyEnvelope(
 		kid = k
 	}
 
-	// Extract unverified payload to get issuer_did for key resolution
 	unverifiedPayload := jws.UnsafePayloadWithoutVerification()
-	if len(unverifiedPayload) > maxSize {
-		return nil, NewError(ErrCodePayloadTooLarge,
-			fmt.Sprintf("payload size %d exceeds maximum %d", len(unverifiedPayload), maxSize))
-	}
-
 	var unverifiedClaims Payload
 	if err := json.Unmarshal(unverifiedPayload, &unverifiedClaims); err != nil {
 		return nil, NewError(ErrCodeMalformed, fmt.Sprintf("failed to unmarshal payload: %v", err))
@@ -201,7 +250,6 @@ func (v *Verifier) VerifyEnvelope(
 			fmt.Sprintf("failed to resolve key for DID %q", unverifiedClaims.IssuerDID), err)
 	}
 
-	// Step 4: Verify JWS signature
 	verifiedPayload, err := jws.Verify(pubKey)
 	if err != nil {
 		return nil, NewError(ErrCodeSignatureInvalid, fmt.Sprintf("signature verification failed: %v", err))
@@ -211,70 +259,58 @@ func (v *Verifier) VerifyEnvelope(
 	if err := json.Unmarshal(verifiedPayload, &payload); err != nil {
 		return nil, NewError(ErrCodeMalformed, fmt.Sprintf("failed to unmarshal verified payload: %v", err))
 	}
-
 	if err := payload.Validate(); err != nil {
 		return nil, err
 	}
+	return &payload, nil
+}
 
-	// Step 5: Temporal validity
-	now := opts.now()
+// checkTemporal validates the envelope's temporal claims.
+func (v *Verifier) checkTemporal(payload *Payload, now time.Time) error {
 	nowUnix := now.Unix()
 	if nowUnix >= payload.ExpiresAt {
-		return nil, NewError(ErrCodeExpired,
+		return NewError(ErrCodeExpired,
 			fmt.Sprintf("envelope expired at %d, current time is %d", payload.ExpiresAt, nowUnix))
 	}
 	if payload.IssuedAt > nowUnix {
-		return nil, NewError(ErrCodeNotYetValid,
+		return NewError(ErrCodeNotYetValid,
 			fmt.Sprintf("envelope issued_at %d is in the future (current time %d)", payload.IssuedAt, nowUnix))
 	}
+	return nil
+}
 
-	// Step 6: Badge JTI binding
-	if issuerBadgeResult != nil {
-		if payload.IssuerBadgeJTI != issuerBadgeResult.Claims.JTI {
-			return nil, NewError(ErrCodeBadgeBindingFailed,
-				fmt.Sprintf("issuer_badge_jti %q does not match presented badge jti %q",
-					payload.IssuerBadgeJTI, issuerBadgeResult.Claims.JTI))
-		}
+// verifySubjectBadge handles subject badge verification and JTI binding.
+func (v *Verifier) verifySubjectBadge(
+	ctx context.Context,
+	payload *Payload,
+	subjectBadgeJWS string,
+	opts VerifyOptions,
+) (*badge.VerifyResult, error) {
+	if opts.SkipBadgeVerification || payload.SubjectBadgeJTI == nil || subjectBadgeJWS == "" {
+		return nil, nil
 	}
-
-	var subjectBadgeResult *badge.VerifyResult
-	if !opts.SkipBadgeVerification && payload.SubjectBadgeJTI != nil && subjectBadgeJWS != "" {
-		if v.BadgeVerifier == nil {
-			return nil, fmt.Errorf("badge verifier is required for subject badge verification")
-		}
-		badgeOpts := badge.VerifyOptions{
-			TrustedIssuers:       opts.TrustedIssuers,
-			AcceptSelfSigned:     true,
-			SkipRevocationCheck:  false,
-			SkipAgentStatusCheck: false,
-		}
-		subjectBadgeResult, err = v.BadgeVerifier.VerifyWithOptions(ctx, subjectBadgeJWS, badgeOpts)
-		if err != nil {
-			return nil, WrapError(ErrCodeBadgeBindingFailed, "subject badge verification failed", err)
-		}
-		if *payload.SubjectBadgeJTI != subjectBadgeResult.Claims.JTI {
-			return nil, NewError(ErrCodeBadgeBindingFailed,
-				fmt.Sprintf("subject_badge_jti %q does not match presented badge jti %q",
-					*payload.SubjectBadgeJTI, subjectBadgeResult.Claims.JTI))
-		}
+	result, err := v.verifyBadge(ctx, subjectBadgeJWS, opts)
+	if err != nil {
+		return nil, WrapError(ErrCodeBadgeBindingFailed, "subject badge verification failed", err)
 	}
-
-	// Step 7: Enforcement mode escalation
-	effectiveMode := opts.EnforcementMode
-	if payload.EnforcementModeMin != nil {
-		minMode, err := ParseEnforcementMode(*payload.EnforcementModeMin)
-		if err != nil {
-			return nil, err
-		}
-		effectiveMode = Escalate(effectiveMode, minMode)
+	if result != nil && *payload.SubjectBadgeJTI != result.Claims.JTI {
+		return nil, NewError(ErrCodeBadgeBindingFailed,
+			fmt.Sprintf("subject_badge_jti %q does not match presented badge jti %q",
+				*payload.SubjectBadgeJTI, result.Claims.JTI))
 	}
+	return result, nil
+}
 
-	return &VerifyResult{
-		Payload:       &payload,
-		IssuerBadge:   issuerBadgeResult,
-		SubjectBadge:  subjectBadgeResult,
-		EffectiveMode: effectiveMode,
-	}, nil
+// resolveEnforcementMode computes the effective enforcement mode.
+func (v *Verifier) resolveEnforcementMode(payload *Payload, configured EnforcementMode) (EnforcementMode, error) {
+	if payload.EnforcementModeMin == nil {
+		return configured, nil
+	}
+	minMode, err := ParseEnforcementMode(*payload.EnforcementModeMin)
+	if err != nil {
+		return 0, err
+	}
+	return Escalate(configured, minMode), nil
 }
 
 // VerifyChain verifies a full delegation chain of Authority Envelopes.

--- a/pkg/envelope/verifier_test.go
+++ b/pkg/envelope/verifier_test.go
@@ -1,0 +1,308 @@
+package envelope_test
+
+import (
+	"context"
+	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
+	"testing"
+	"time"
+
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// testKeyResolver maps DIDs to public keys for testing.
+type testKeyResolver struct {
+	keys map[string]crypto.PublicKey
+}
+
+func (r *testKeyResolver) resolve(_ context.Context, didStr string, _ string) (crypto.PublicKey, error) {
+	if key, ok := r.keys[didStr]; ok {
+		return key, nil
+	}
+	return envelope.DefaultKeyResolver(context.Background(), didStr, "")
+}
+
+func newResolver(pairs ...interface{}) *testKeyResolver {
+	r := &testKeyResolver{keys: make(map[string]crypto.PublicKey)}
+	for i := 0; i < len(pairs); i += 2 {
+		r.keys[pairs[i].(string)] = pairs[i+1].(crypto.PublicKey)
+	}
+	return r
+}
+
+func signTestEnvelope(t *testing.T, payload *envelope.Payload, priv ed25519.PrivateKey, kid string) string {
+	t.Helper()
+	token, err := envelope.SignEnvelope(payload, priv, kid)
+	require.NoError(t, err)
+	return token
+}
+
+func TestVerifyEnvelope_ValidRootEnvelope(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	payload := testPayload(t, issuerDID, subjectDID)
+
+	token := signTestEnvelope(t, payload, priv, issuerDID+"#key-1")
+
+	v := &envelope.Verifier{
+		KeyResolver: envelope.DefaultKeyResolver,
+	}
+
+	result, err := v.VerifyEnvelope(context.Background(), token, "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, payload.EnvelopeID, result.Payload.EnvelopeID)
+	assert.Equal(t, payload.IssuerDID, result.Payload.IssuerDID)
+	assert.Equal(t, payload.SubjectDID, result.Payload.SubjectDID)
+}
+
+func TestVerifyEnvelope_ExpiredEnvelope(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	payload := testPayload(t, issuerDID, subjectDID)
+	payload.ExpiresAt = time.Now().Add(-1 * time.Hour).Unix() // expired
+	payload.IssuedAt = time.Now().Add(-2 * time.Hour).Unix()
+
+	token := signTestEnvelope(t, payload, priv, issuerDID+"#key-1")
+
+	v := &envelope.Verifier{KeyResolver: envelope.DefaultKeyResolver}
+	_, err := v.VerifyEnvelope(context.Background(), token, "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+	})
+	require.Error(t, err)
+
+	var envErr *envelope.Error
+	require.ErrorAs(t, err, &envErr)
+	assert.Equal(t, "ENVELOPE_EXPIRED", envErr.Code)
+}
+
+func TestVerifyEnvelope_FutureIssuedAt(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	payload := testPayload(t, issuerDID, subjectDID)
+	payload.IssuedAt = time.Now().Add(2 * time.Hour).Unix()    // future
+	payload.ExpiresAt = time.Now().Add(3 * time.Hour).Unix()
+
+	token := signTestEnvelope(t, payload, priv, issuerDID+"#key-1")
+
+	v := &envelope.Verifier{KeyResolver: envelope.DefaultKeyResolver}
+	_, err := v.VerifyEnvelope(context.Background(), token, "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+	})
+	require.Error(t, err)
+
+	var envErr *envelope.Error
+	require.ErrorAs(t, err, &envErr)
+	assert.Equal(t, "ENVELOPE_NOT_YET_VALID", envErr.Code)
+}
+
+func TestVerifyEnvelope_WrongSigningKey(t *testing.T) {
+	pub, _ := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	_, wrongPriv := generateTestKey(t) // different key
+	subPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	payload := testPayload(t, issuerDID, subjectDID)
+	token := signTestEnvelope(t, payload, wrongPriv, issuerDID+"#key-1")
+
+	v := &envelope.Verifier{KeyResolver: envelope.DefaultKeyResolver}
+	_, err := v.VerifyEnvelope(context.Background(), token, "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+	})
+	require.Error(t, err)
+
+	var envErr *envelope.Error
+	require.ErrorAs(t, err, &envErr)
+	assert.Equal(t, "ENVELOPE_SIGNATURE_INVALID", envErr.Code)
+}
+
+func TestVerifyEnvelope_EnforcementModeEscalation(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	emStr := "EM-STRICT"
+	payload := testPayload(t, issuerDID, subjectDID)
+	payload.EnforcementModeMin = &emStr
+
+	token := signTestEnvelope(t, payload, priv, issuerDID+"#key-1")
+
+	v := &envelope.Verifier{KeyResolver: envelope.DefaultKeyResolver}
+	result, err := v.VerifyEnvelope(context.Background(), token, "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+		EnforcementMode:       envelope.EMObserve,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, envelope.EMStrict, result.EffectiveMode)
+}
+
+func TestVerifyEnvelope_MalformedJWS(t *testing.T) {
+	v := &envelope.Verifier{KeyResolver: envelope.DefaultKeyResolver}
+	_, err := v.VerifyEnvelope(context.Background(), "not.a.jws", "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+	})
+	require.Error(t, err)
+
+	var envErr *envelope.Error
+	require.ErrorAs(t, err, &envErr)
+	assert.Equal(t, "ENVELOPE_MALFORMED", envErr.Code)
+}
+
+func TestVerifyEnvelope_TimeOverride(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	now := time.Date(2030, 1, 1, 0, 0, 0, 0, time.UTC)
+	payload := testPayload(t, issuerDID, subjectDID)
+	payload.IssuedAt = now.Unix()
+	payload.ExpiresAt = now.Add(time.Hour).Unix()
+
+	token := signTestEnvelope(t, payload, priv, issuerDID+"#key-1")
+
+	v := &envelope.Verifier{KeyResolver: envelope.DefaultKeyResolver}
+
+	// Without time override — current time is before issued_at
+	_, err := v.VerifyEnvelope(context.Background(), token, "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+	})
+	require.Error(t, err)
+
+	// With time override — should pass
+	result, err := v.VerifyEnvelope(context.Background(), token, "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+		Now:                   func() time.Time { return now.Add(30 * time.Minute) },
+	})
+	require.NoError(t, err)
+	assert.Equal(t, payload.EnvelopeID, result.Payload.EnvelopeID)
+}
+
+func TestVerifyChain_ValidTwoHop(t *testing.T) {
+	pubA, privA := generateTestKey(t)
+	pubB, privB := generateTestKey(t)
+	pubC, _ := generateTestKey(t)
+
+	didA := testDID(t, pubA)
+	didB := testDID(t, pubB)
+	didC := testDID(t, pubC)
+
+	now := time.Now()
+	txnID := uuid.New().String()
+
+	// Root
+	root := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                didA,
+		SubjectDID:               didB,
+		TxnID:                    txnID,
+		CapabilityClass:          "tools.database",
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: 3,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(time.Hour).Unix(),
+		IssuerBadgeJTI:           uuid.New().String(),
+	}
+	rootJWS := signTestEnvelope(t, root, privA, didA+"#key-1")
+	rootToken, err := envelope.ParseToken(rootJWS)
+	require.NoError(t, err)
+
+	// Child
+	child := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                didB,
+		SubjectDID:               didC,
+		TxnID:                    txnID,
+		CapabilityClass:          "tools.database.read",
+		Constraints:              map[string]any{},
+		DelegationDepthRemaining: 2,
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(30 * time.Minute).Unix(),
+		IssuerBadgeJTI:           uuid.New().String(),
+	}
+	childJWS, err := envelope.DeriveEnvelope(rootToken, child, privB, didB+"#key-1")
+	require.NoError(t, err)
+
+	v := &envelope.Verifier{KeyResolver: envelope.DefaultKeyResolver}
+	result, err := v.VerifyChain(
+		context.Background(),
+		[]string{rootJWS, childJWS},
+		map[string]string{},
+		envelope.VerifyOptions{SkipBadgeVerification: true},
+	)
+	require.NoError(t, err)
+	assert.Equal(t, 2, len(result.Links))
+	assert.Equal(t, "tools.database", result.RootCapability)
+	assert.Equal(t, "tools.database.read", result.LeafCapability)
+	assert.Equal(t, 1, result.TotalDepth)
+}
+
+func TestVerifyChain_Empty(t *testing.T) {
+	v := &envelope.Verifier{KeyResolver: envelope.DefaultKeyResolver}
+	_, err := v.VerifyChain(context.Background(), []string{}, map[string]string{}, envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+	})
+	require.Error(t, err)
+}
+
+func TestVerifyEnvelope_PayloadTooLarge(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	payload := testPayload(t, issuerDID, subjectDID)
+	// Add a large constraints field
+	bigData := make(map[string]any)
+	for i := 0; i < 500; i++ {
+		bigData[uuid.New().String()] = uuid.New().String()
+	}
+	payload.Constraints = bigData
+
+	token := signTestEnvelope(t, payload, priv, issuerDID+"#key-1")
+
+	v := &envelope.Verifier{KeyResolver: envelope.DefaultKeyResolver}
+	_, err := v.VerifyEnvelope(context.Background(), token, "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+		MaxPayloadSize:        100, // very small limit
+	})
+	require.Error(t, err)
+
+	var envErr *envelope.Error
+	require.ErrorAs(t, err, &envErr)
+	assert.Equal(t, "ENVELOPE_PAYLOAD_TOO_LARGE", envErr.Code)
+}
+
+func TestVerifyEnvelope_DefaultKeyResolver_DidKey(t *testing.T) {
+	pub, priv := generateTestKey(t)
+	issuerDID := testDID(t, pub)
+	subPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	subjectDID := testDID(t, subPub)
+
+	payload := testPayload(t, issuerDID, subjectDID)
+	token := signTestEnvelope(t, payload, priv, issuerDID+"#key-1")
+
+	// Verify using DefaultKeyResolver (did:key)
+	v := &envelope.Verifier{} // nil KeyResolver → uses DefaultKeyResolver
+	result, err := v.VerifyEnvelope(context.Background(), token, "", "", envelope.VerifyOptions{
+		SkipBadgeVerification: true,
+	})
+	require.NoError(t, err)
+	assert.Equal(t, payload.EnvelopeID, result.Payload.EnvelopeID)
+}


### PR DESCRIPTION
## Summary

Implements delegated capability authorization via Authority Envelopes as specified in [RFC-008](https://docs.capisc.io/rfcs/rfc-008-authority-envelopes/).

## What's included

### Package `pkg/envelope` (8 source files, 6 test files)

**Data types & core (`envelope.go`, `errors.go`)**
- `Payload` struct with all 13 RFC-008 claims (JSON-tagged, optional fields as pointers)
- `Token` struct wrapping raw JWS + parsed payload
- `ComputeHash()` — SHA-256 hex lowercase of JWS compact string
- 12 typed error codes with cause chaining

**Signing (`issuer.go`)**
- `SignEnvelope()` — validates payload, signs with EdDSA, sets `typ` header

**Capability validation (`capability.go`)**
- `ValidateCapabilityClass()` — dot-separated lowercase segment validation
- `IsWithinScope()` — prefix-based scope matching at segment boundaries

**Enforcement modes (`enforcement.go`)**
- 4 monotonic modes: EM-OBSERVE < EM-GUARD < EM-DELEGATE < EM-STRICT
- `Escalate()` — returns max(configured, minimum)

**Narrowing (`narrowing.go`)**
- `ValidateNarrowing()` — checks 4 dimensions: DID chain, capability scope, temporal bounds, depth decrement

**Chain management (`chain.go`)**
- `DeriveEnvelope()` — creates child envelope from parent with hash linking
- `ValidateChainIntegrity()` — validates hash links, DID continuity, narrowing, txn_id consistency

**Verification (`verifier.go`)**
- `Verifier` with pluggable `KeyResolver` and optional `BadgeVerifier`
- `VerifyEnvelope()` — 7-step verification per RFC-008 §9.2
- `VerifyChain()` — full delegation chain verification
- `DefaultKeyResolver` — supports did:key (Ed25519)

### CLI (`cmd/capiscio/envelope.go`)

5 subcommands:
- `capiscio envelope issue` — create root authority envelopes
- `capiscio envelope derive` — delegate with narrowed permissions
- `capiscio envelope verify` — verify single envelope
- `capiscio envelope chain` — verify delegation chain
- `capiscio envelope inspect` — parse without verification

### Test coverage (30+ test cases)

- Round-trip signing/parsing
- Capability class validation (valid + invalid patterns)
- Scope matching (prefix, sibling, partial boundary)
- Enforcement mode parsing and escalation
- Narrowing validation (all 4 dimensions, 11 table-driven cases)
- Chain integrity (3-hop, tampered hash, missing root, txn_id mismatch)
- Depth exceeded
- Verifier: valid root, expired, future issued_at, wrong key, malformed JWS, time override, mode escalation, payload too large, chain verification, default key resolver

## What's deferred (per plan)

- PDP integration (RFC-008 §8.5 constraint subset validation)
- Invocation evidence (RFC-004, not yet published)
- Transport bindings (HTTP headers, MCP _meta, A2A metadata)
- Server endpoints
- SDK wrappers
- did:web resolution

## Verification

```bash
go build ./pkg/envelope/...     # ✅ compiles
go test ./pkg/envelope/... -v   # ✅ 30+ tests pass
go test -race ./pkg/envelope/.. # ✅ no race conditions
go test ./...                   # ✅ no regressions (integration test excluded — no server)
./bin/capiscio envelope --help  # ✅ all 5 subcommands visible
```