### PR TITLE
feat: RFC-008 capability class support (ALLOW path)

### DIFF
--- a/internal/rpc/mcp_service.go
+++ b/internal/rpc/mcp_service.go
@@ -159,13 +159,17 @@ func (s *MCPService) EvaluateToolAccess(
 	}
 
 	// Evaluate tool access
-	result, err := s.service.EvaluateToolAccess(ctx, &mcp.EvaluateToolAccessInput{
-		ToolName:   req.ToolName,
-		ParamsHash: req.ParamsHash,
-		Origin:     req.ServerOrigin,
-		Credential: cred,
-		Config:     config,
-	})
+	evalInput := &mcp.EvaluateToolAccessInput{
+		ToolName:           req.ToolName,
+		ParamsHash:         req.ParamsHash,
+		Origin:             req.ServerOrigin,
+		Credential:         cred,
+		Config:             config,
+		CapabilityClass:    req.CapabilityClass,
+		DenyOnUnknownClass: req.DenyOnUnknownClass,
+	}
+
+	result, err := s.service.EvaluateToolAccess(ctx, evalInput)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/mcp/service.go
+++ b/pkg/mcp/service.go
@@ -33,11 +33,13 @@ func NewService(deps *Dependencies) *Service {
 
 // EvaluateToolAccessInput represents the input for tool access evaluation
 type EvaluateToolAccessInput struct {
-	ToolName   string
-	ParamsHash string
-	Origin     string
-	Credential CallerCredential
-	Config     *EvaluateConfig
+	ToolName           string
+	ParamsHash         string
+	Origin             string
+	Credential         CallerCredential
+	Config             *EvaluateConfig
+	CapabilityClass    string // RFC-008: capability class for policy evaluation
+	DenyOnUnknownClass *bool  // RFC-008: PEP-level unknown class behavior (nil = deny)
 }
 
 // EvaluateToolAccess evaluates tool access using RFC-006 §6.2-6.4

--- a/pkg/pdp/opa_client.go
+++ b/pkg/pdp/opa_client.go
@@ -193,6 +193,11 @@ func buildOPAInput(req *pip.DecisionRequest) map[string]interface{} {
 		env["time"] = *req.Environment.Time
 	}
 
+	// RFC-008: PEP-level flag for unknown capability class behavior
+	if req.DenyOnUnknownClass != nil {
+		input["deny_on_unknown_class"] = *req.DenyOnUnknownClass
+	}
+
 	return input
 }
 

--- a/pkg/pip/types.go
+++ b/pkg/pip/types.go
@@ -17,12 +17,13 @@ const (
 
 // DecisionRequest is the canonical PDP query (RFC-005 §5.1).
 type DecisionRequest struct {
-	PIPVersion  string             `json:"pip_version"`
-	Subject     SubjectAttributes  `json:"subject"`
-	Action      ActionAttributes   `json:"action"`
-	Resource    ResourceAttributes `json:"resource"`
-	Context     ContextAttributes  `json:"context"`
-	Environment EnvironmentAttrs   `json:"environment"`
+	PIPVersion         string             `json:"pip_version"`
+	Subject            SubjectAttributes  `json:"subject"`
+	Action             ActionAttributes   `json:"action"`
+	Resource           ResourceAttributes `json:"resource"`
+	Context            ContextAttributes  `json:"context"`
+	Environment        EnvironmentAttrs   `json:"environment"`
+	DenyOnUnknownClass *bool              `json:"deny_on_unknown_class,omitempty"` // RFC-008: PEP-level flag for unknown capability class behavior
 }
 
 // SubjectAttributes identifies the acting agent.

--- a/pkg/policy/config.go
+++ b/pkg/policy/config.go
@@ -5,9 +5,9 @@ package policy
 
 import (
 	"fmt"
-	"regexp"
 	"strings"
 
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
 	"gopkg.in/yaml.v3"
 )
 
@@ -48,7 +48,7 @@ type MCPToolRule struct {
 }
 
 // CapabilityClassRule scopes policy to a specific RFC-008 capability class.
-// The Class field uses dot-notation per RFC-008 §7.1 (e.g. "invoice-management").
+// The Class field uses dot-notation per RFC-008 §7.1 (e.g. "invoice_management").
 type CapabilityClassRule struct {
 	Class         string   `yaml:"class" json:"class"`
 	MinTrustLevel string   `yaml:"min_trust_level" json:"min_trust_level"`
@@ -65,10 +65,6 @@ var validTrustLevels = map[string]bool{
 	"OV":  true,
 	"EV":  true,
 }
-
-// capabilityClassPattern validates RFC-008 §7.1 dot-notation class names.
-// Allowed characters: lowercase letters, digits, hyphens, and dots as separators.
-var capabilityClassPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$`)
 
 // Parse parses and validates YAML policy config bytes.
 // Returns an error if the YAML is malformed or fails validation.
@@ -168,17 +164,29 @@ func Validate(cfg *Config) error {
 	}
 
 	// Validate capability classes (RFC-008 §7.1)
+	errs = append(errs, validateCapabilityClasses(cfg.CapabilityClasses)...)
+
+	if len(errs) > 0 {
+		return fmt.Errorf("policy config validation failed:\n  - %s", strings.Join(errs, "\n  - "))
+	}
+	return nil
+}
+
+// validateCapabilityClasses validates the capability_classes section of a policy.
+func validateCapabilityClasses(classes []CapabilityClassRule) []string {
+	var errs []string
 	ccSeen := make(map[string]bool)
-	for i, cc := range cfg.CapabilityClasses {
+	for i, cc := range classes {
 		if cc.Class == "" {
 			errs = append(errs, fmt.Sprintf("capability_classes[%d]: class must not be empty", i))
-		} else if !capabilityClassPattern.MatchString(cc.Class) {
-			errs = append(errs, fmt.Sprintf("capability_classes[%d]: invalid class name %q (must match [a-z0-9-] with optional dot separators)", i, cc.Class))
+		} else if err := envelope.ValidateCapabilityClass(cc.Class); err != nil {
+			errs = append(errs, fmt.Sprintf("capability_classes[%d]: invalid class name %q: %v", i, cc.Class, err))
+		} else {
+			if ccSeen[cc.Class] {
+				errs = append(errs, fmt.Sprintf("capability_classes[%d]: duplicate class %q", i, cc.Class))
+			}
+			ccSeen[cc.Class] = true
 		}
-		if ccSeen[cc.Class] {
-			errs = append(errs, fmt.Sprintf("capability_classes[%d]: duplicate class %q", i, cc.Class))
-		}
-		ccSeen[cc.Class] = true
 		if !validTrustLevels[cc.MinTrustLevel] {
 			errs = append(errs, fmt.Sprintf("capability_classes[%d]: invalid min_trust_level %q", i, cc.MinTrustLevel))
 		}
@@ -187,11 +195,7 @@ func Validate(cfg *Config) error {
 		_, ccDeniedErrs := validateDIDList(fmt.Sprintf("capability_classes[%d].denied_dids", i), cc.DeniedDIDs, ccAllowedSeen)
 		errs = append(errs, ccDeniedErrs...)
 	}
-
-	if len(errs) > 0 {
-		return fmt.Errorf("policy config validation failed:\n  - %s", strings.Join(errs, "\n  - "))
-	}
-	return nil
+	return errs
 }
 
 // ToMap converts a Config to the map format used in OPA data documents.

--- a/pkg/policy/config.go
+++ b/pkg/policy/config.go
@@ -5,6 +5,7 @@ package policy
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -14,13 +15,14 @@ import (
 // This defines the content of a policy document at any scope level
 // (org, group, or agent).
 type Config struct {
-	Version       string          `yaml:"version" json:"version"`
-	MinTrustLevel string          `yaml:"min_trust_level" json:"min_trust_level"`
-	AllowedDIDs   []string        `yaml:"allowed_dids" json:"allowed_dids"`
-	DeniedDIDs    []string        `yaml:"denied_dids" json:"denied_dids"`
-	RateLimits    []RateLimitRule `yaml:"rate_limits" json:"rate_limits"`
-	Operations    []OperationRule `yaml:"operations" json:"operations"`
-	MCPTools      []MCPToolRule   `yaml:"mcp_tools" json:"mcp_tools"`
+	Version           string                `yaml:"version" json:"version"`
+	MinTrustLevel     string                `yaml:"min_trust_level" json:"min_trust_level"`
+	AllowedDIDs       []string              `yaml:"allowed_dids" json:"allowed_dids"`
+	DeniedDIDs        []string              `yaml:"denied_dids" json:"denied_dids"`
+	RateLimits        []RateLimitRule        `yaml:"rate_limits" json:"rate_limits"`
+	Operations        []OperationRule        `yaml:"operations" json:"operations"`
+	MCPTools          []MCPToolRule          `yaml:"mcp_tools" json:"mcp_tools"`
+	CapabilityClasses []CapabilityClassRule  `yaml:"capability_classes" json:"capability_classes"`
 }
 
 // RateLimitRule defines per-DID rate limiting.
@@ -45,6 +47,15 @@ type MCPToolRule struct {
 	DeniedDIDs    []string `yaml:"denied_dids" json:"denied_dids"`
 }
 
+// CapabilityClassRule scopes policy to a specific RFC-008 capability class.
+// The Class field uses dot-notation per RFC-008 §7.1 (e.g. "invoice-management").
+type CapabilityClassRule struct {
+	Class         string   `yaml:"class" json:"class"`
+	MinTrustLevel string   `yaml:"min_trust_level" json:"min_trust_level"`
+	AllowedDIDs   []string `yaml:"allowed_dids" json:"allowed_dids"`
+	DeniedDIDs    []string `yaml:"denied_dids" json:"denied_dids"`
+}
+
 // validTrustLevels defines the allowed trust level values.
 var validTrustLevels = map[string]bool{
 	"":    true, // empty means no trust requirement
@@ -54,6 +65,10 @@ var validTrustLevels = map[string]bool{
 	"OV":  true,
 	"EV":  true,
 }
+
+// capabilityClassPattern validates RFC-008 §7.1 dot-notation class names.
+// Allowed characters: lowercase letters, digits, hyphens, and dots as separators.
+var capabilityClassPattern = regexp.MustCompile(`^[a-z0-9]([a-z0-9-]*[a-z0-9])?(\.[a-z0-9]([a-z0-9-]*[a-z0-9])?)*$`)
 
 // Parse parses and validates YAML policy config bytes.
 // Returns an error if the YAML is malformed or fails validation.
@@ -152,6 +167,27 @@ func Validate(cfg *Config) error {
 		errs = append(errs, toolDeniedErrs...)
 	}
 
+	// Validate capability classes (RFC-008 §7.1)
+	ccSeen := make(map[string]bool)
+	for i, cc := range cfg.CapabilityClasses {
+		if cc.Class == "" {
+			errs = append(errs, fmt.Sprintf("capability_classes[%d]: class must not be empty", i))
+		} else if !capabilityClassPattern.MatchString(cc.Class) {
+			errs = append(errs, fmt.Sprintf("capability_classes[%d]: invalid class name %q (must match [a-z0-9-] with optional dot separators)", i, cc.Class))
+		}
+		if ccSeen[cc.Class] {
+			errs = append(errs, fmt.Sprintf("capability_classes[%d]: duplicate class %q", i, cc.Class))
+		}
+		ccSeen[cc.Class] = true
+		if !validTrustLevels[cc.MinTrustLevel] {
+			errs = append(errs, fmt.Sprintf("capability_classes[%d]: invalid min_trust_level %q", i, cc.MinTrustLevel))
+		}
+		ccAllowedSeen, ccDIDErrs := validateDIDList(fmt.Sprintf("capability_classes[%d].allowed_dids", i), cc.AllowedDIDs, nil)
+		errs = append(errs, ccDIDErrs...)
+		_, ccDeniedErrs := validateDIDList(fmt.Sprintf("capability_classes[%d].denied_dids", i), cc.DeniedDIDs, ccAllowedSeen)
+		errs = append(errs, ccDeniedErrs...)
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("policy config validation failed:\n  - %s", strings.Join(errs, "\n  - "))
 	}
@@ -227,6 +263,26 @@ func ToMap(cfg *Config) map[string]interface{} {
 		tools[i] = entry
 	}
 	result["mcp_tools"] = tools
+
+	ccRules := make([]interface{}, len(cfg.CapabilityClasses))
+	for i, cc := range cfg.CapabilityClasses {
+		entry := map[string]interface{}{
+			"class":           cc.Class,
+			"min_trust_level": cc.MinTrustLevel,
+		}
+		ccAllowed := make([]interface{}, len(cc.AllowedDIDs))
+		for j, d := range cc.AllowedDIDs {
+			ccAllowed[j] = d
+		}
+		entry["allowed_dids"] = ccAllowed
+		ccDenied := make([]interface{}, len(cc.DeniedDIDs))
+		for j, d := range cc.DeniedDIDs {
+			ccDenied[j] = d
+		}
+		entry["denied_dids"] = ccDenied
+		ccRules[i] = entry
+	}
+	result["capability_classes"] = ccRules
 
 	return result
 }

--- a/pkg/policy/config_test.go
+++ b/pkg/policy/config_test.go
@@ -295,11 +295,11 @@ func TestParse_CapabilityClasses(t *testing.T) {
 	yaml := `version: "1"
 min_trust_level: DV
 capability_classes:
-  - class: invoice-management
+  - class: invoice_management
     min_trust_level: OV
     allowed_dids:
       - did:web:agent1.example.com
-  - class: finance.invoice-management
+  - class: finance.invoice_management
     min_trust_level: EV
     denied_dids:
       - did:web:evil.example.com
@@ -307,10 +307,10 @@ capability_classes:
 	cfg, err := Parse([]byte(yaml))
 	require.NoError(t, err)
 	assert.Len(t, cfg.CapabilityClasses, 2)
-	assert.Equal(t, "invoice-management", cfg.CapabilityClasses[0].Class)
+	assert.Equal(t, "invoice_management", cfg.CapabilityClasses[0].Class)
 	assert.Equal(t, "OV", cfg.CapabilityClasses[0].MinTrustLevel)
 	assert.Equal(t, []string{"did:web:agent1.example.com"}, cfg.CapabilityClasses[0].AllowedDIDs)
-	assert.Equal(t, "finance.invoice-management", cfg.CapabilityClasses[1].Class)
+	assert.Equal(t, "finance.invoice_management", cfg.CapabilityClasses[1].Class)
 	assert.Equal(t, "EV", cfg.CapabilityClasses[1].MinTrustLevel)
 }
 
@@ -329,20 +329,20 @@ func TestValidate_CapabilityClassDotNotation(t *testing.T) {
 		class   string
 		wantErr bool
 	}{
-		{"simple", "invoice-management", false},
-		{"dotted", "finance.invoice-management", false},
-		{"deep-dotted", "finance.accounts.invoice-management", false},
+		{"simple", "invoice_management", false},
+		{"dotted", "finance.invoice_management", false},
+		{"deep-dotted", "finance.accounts.invoice_management", false},
 		{"single-char", "a", false},
-		{"numeric", "rfc008", false},
+		{"with-digits", "rfc008", false},
+		{"underscore", "has_underscore", false},
 		{"empty", "", true},
-		{"leading-dot", ".leading-dot", true},
-		{"trailing-dot", "trailing-dot.", true},
+		{"leading-dot", ".leading", true},
+		{"trailing-dot", "trailing.", true},
 		{"double-dot", "finance..invoice", true},
 		{"uppercase", "UPPERCASE", true},
 		{"spaces", "has space", true},
-		{"underscore", "has_underscore", true},
-		{"leading-hyphen", "-leading", true},
-		{"trailing-hyphen", "trailing-", true},
+		{"hyphen", "invoice-management", true},
+		{"leading-digit", "0abc", true},
 	}
 
 	for _, tt := range tests {
@@ -367,20 +367,20 @@ func TestValidate_CapabilityClassDuplicate(t *testing.T) {
 	cfg := &Config{
 		Version: "1",
 		CapabilityClasses: []CapabilityClassRule{
-			{Class: "invoice-management", MinTrustLevel: "DV"},
-			{Class: "invoice-management", MinTrustLevel: "OV"},
+			{Class: "invoice_management", MinTrustLevel: "DV"},
+			{Class: "invoice_management", MinTrustLevel: "OV"},
 		},
 	}
 	err := Validate(cfg)
 	require.Error(t, err)
-	assert.Contains(t, err.Error(), `duplicate class "invoice-management"`)
+	assert.Contains(t, err.Error(), `duplicate class "invoice_management"`)
 }
 
 func TestValidate_CapabilityClassInvalidTrustLevel(t *testing.T) {
 	cfg := &Config{
 		Version: "1",
 		CapabilityClasses: []CapabilityClassRule{
-			{Class: "invoice-management", MinTrustLevel: "GOLD"},
+			{Class: "invoice_management", MinTrustLevel: "GOLD"},
 		},
 	}
 	err := Validate(cfg)
@@ -393,7 +393,7 @@ func TestValidate_CapabilityClassDIDConflict(t *testing.T) {
 		Version: "1",
 		CapabilityClasses: []CapabilityClassRule{
 			{
-				Class:       "invoice-management",
+				Class:       "invoice_management",
 				AllowedDIDs: []string{"did:web:a.example.com"},
 				DeniedDIDs:  []string{"did:web:a.example.com"},
 			},
@@ -415,7 +415,7 @@ func TestToMap_WithCapabilityClasses(t *testing.T) {
 		MCPTools:      []MCPToolRule{},
 		CapabilityClasses: []CapabilityClassRule{
 			{
-				Class:         "invoice-management",
+				Class:         "invoice_management",
 				MinTrustLevel: "OV",
 				AllowedDIDs:   []string{"did:web:a.example.com"},
 				DeniedDIDs:    []string{},
@@ -428,6 +428,6 @@ func TestToMap_WithCapabilityClasses(t *testing.T) {
 	require.True(t, ok)
 	require.Len(t, ccRules, 1)
 	cc := ccRules[0].(map[string]interface{})
-	assert.Equal(t, "invoice-management", cc["class"])
+	assert.Equal(t, "invoice_management", cc["class"])
 	assert.Equal(t, "OV", cc["min_trust_level"])
 }

--- a/pkg/policy/config_test.go
+++ b/pkg/policy/config_test.go
@@ -288,3 +288,146 @@ func TestValidate_MCPToolDIDConflict(t *testing.T) {
 	assert.Contains(t, err.Error(), "mcp_tools[0].denied_dids")
 	assert.Contains(t, err.Error(), "conflicts with allowed")
 }
+
+// --- Capability Class Tests (RFC-008 §7.1) ---
+
+func TestParse_CapabilityClasses(t *testing.T) {
+	yaml := `version: "1"
+min_trust_level: DV
+capability_classes:
+  - class: invoice-management
+    min_trust_level: OV
+    allowed_dids:
+      - did:web:agent1.example.com
+  - class: finance.invoice-management
+    min_trust_level: EV
+    denied_dids:
+      - did:web:evil.example.com
+`
+	cfg, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+	assert.Len(t, cfg.CapabilityClasses, 2)
+	assert.Equal(t, "invoice-management", cfg.CapabilityClasses[0].Class)
+	assert.Equal(t, "OV", cfg.CapabilityClasses[0].MinTrustLevel)
+	assert.Equal(t, []string{"did:web:agent1.example.com"}, cfg.CapabilityClasses[0].AllowedDIDs)
+	assert.Equal(t, "finance.invoice-management", cfg.CapabilityClasses[1].Class)
+	assert.Equal(t, "EV", cfg.CapabilityClasses[1].MinTrustLevel)
+}
+
+func TestParse_EmptyCapabilityClasses(t *testing.T) {
+	yaml := `version: "1"
+min_trust_level: REG
+`
+	cfg, err := Parse([]byte(yaml))
+	require.NoError(t, err)
+	assert.Empty(t, cfg.CapabilityClasses)
+}
+
+func TestValidate_CapabilityClassDotNotation(t *testing.T) {
+	tests := []struct {
+		name    string
+		class   string
+		wantErr bool
+	}{
+		{"simple", "invoice-management", false},
+		{"dotted", "finance.invoice-management", false},
+		{"deep-dotted", "finance.accounts.invoice-management", false},
+		{"single-char", "a", false},
+		{"numeric", "rfc008", false},
+		{"empty", "", true},
+		{"leading-dot", ".leading-dot", true},
+		{"trailing-dot", "trailing-dot.", true},
+		{"double-dot", "finance..invoice", true},
+		{"uppercase", "UPPERCASE", true},
+		{"spaces", "has space", true},
+		{"underscore", "has_underscore", true},
+		{"leading-hyphen", "-leading", true},
+		{"trailing-hyphen", "trailing-", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Version: "1",
+				CapabilityClasses: []CapabilityClassRule{
+					{Class: tt.class, MinTrustLevel: "DV"},
+				},
+			}
+			err := Validate(cfg)
+			if tt.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestValidate_CapabilityClassDuplicate(t *testing.T) {
+	cfg := &Config{
+		Version: "1",
+		CapabilityClasses: []CapabilityClassRule{
+			{Class: "invoice-management", MinTrustLevel: "DV"},
+			{Class: "invoice-management", MinTrustLevel: "OV"},
+		},
+	}
+	err := Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `duplicate class "invoice-management"`)
+}
+
+func TestValidate_CapabilityClassInvalidTrustLevel(t *testing.T) {
+	cfg := &Config{
+		Version: "1",
+		CapabilityClasses: []CapabilityClassRule{
+			{Class: "invoice-management", MinTrustLevel: "GOLD"},
+		},
+	}
+	err := Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid min_trust_level "GOLD"`)
+}
+
+func TestValidate_CapabilityClassDIDConflict(t *testing.T) {
+	cfg := &Config{
+		Version: "1",
+		CapabilityClasses: []CapabilityClassRule{
+			{
+				Class:       "invoice-management",
+				AllowedDIDs: []string{"did:web:a.example.com"},
+				DeniedDIDs:  []string{"did:web:a.example.com"},
+			},
+		},
+	}
+	err := Validate(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "capability_classes[0].denied_dids")
+	assert.Contains(t, err.Error(), "conflicts with allowed")
+}
+
+func TestToMap_WithCapabilityClasses(t *testing.T) {
+	cfg := &Config{
+		MinTrustLevel: "DV",
+		AllowedDIDs:   []string{},
+		DeniedDIDs:    []string{},
+		RateLimits:    []RateLimitRule{},
+		Operations:    []OperationRule{},
+		MCPTools:      []MCPToolRule{},
+		CapabilityClasses: []CapabilityClassRule{
+			{
+				Class:         "invoice-management",
+				MinTrustLevel: "OV",
+				AllowedDIDs:   []string{"did:web:a.example.com"},
+				DeniedDIDs:    []string{},
+			},
+		},
+	}
+
+	m := ToMap(cfg)
+	ccRules, ok := m["capability_classes"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, ccRules, 1)
+	cc := ccRules[0].(map[string]interface{})
+	assert.Equal(t, "invoice-management", cc["class"])
+	assert.Equal(t, "OV", cc["min_trust_level"])
+}

--- a/pkg/rpc/gen/capiscio/v1/mcp.pb.go
+++ b/pkg/rpc/gen/capiscio/v1/mcp.pb.go
@@ -354,8 +354,10 @@ type EvaluateToolAccessRequest struct {
 	DelegationDepth       int32  `protobuf:"varint,12,opt,name=delegation_depth,json=delegationDepth,proto3" json:"delegation_depth,omitempty"`                    // reserved for envelope
 	ConstraintsJson       string `protobuf:"bytes,13,opt,name=constraints_json,json=constraintsJson,proto3" json:"constraints_json,omitempty"`                     // reserved for envelope
 	ParentConstraintsJson string `protobuf:"bytes,14,opt,name=parent_constraints_json,json=parentConstraintsJson,proto3" json:"parent_constraints_json,omitempty"` // reserved for envelope
-	unknownFields         protoimpl.UnknownFields
-	sizeCache             protoimpl.SizeCache
+	// RFC-008: PEP-level unknown capability class behavior (default: deny)
+	DenyOnUnknownClass *bool `protobuf:"varint,15,opt,name=deny_on_unknown_class,json=denyOnUnknownClass,proto3,oneof" json:"deny_on_unknown_class,omitempty"`
+	unknownFields      protoimpl.UnknownFields
+	sizeCache          protoimpl.SizeCache
 }
 
 func (x *EvaluateToolAccessRequest) Reset() {
@@ -488,6 +490,13 @@ func (x *EvaluateToolAccessRequest) GetParentConstraintsJson() string {
 		return x.ParentConstraintsJson
 	}
 	return ""
+}
+
+func (x *EvaluateToolAccessRequest) GetDenyOnUnknownClass() bool {
+	if x != nil && x.DenyOnUnknownClass != nil {
+		return *x.DenyOnUnknownClass
+	}
+	return false
 }
 
 type isEvaluateToolAccessRequest_CallerCredential interface {
@@ -1928,7 +1937,7 @@ var File_capiscio_v1_mcp_proto protoreflect.FileDescriptor
 
 const file_capiscio_v1_mcp_proto_rawDesc = "" +
 	"\n" +
-	"\x15capiscio/v1/mcp.proto\x12\vcapiscio.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\xb4\x04\n" +
+	"\x15capiscio/v1/mcp.proto\x12\vcapiscio.v1\x1a\x1fgoogle/protobuf/timestamp.proto\"\x86\x05\n" +
 	"\x19EvaluateToolAccessRequest\x12\x1b\n" +
 	"\ttool_name\x18\x01 \x01(\tR\btoolName\x12\x1f\n" +
 	"\vparams_hash\x18\x02 \x01(\tR\n" +
@@ -1945,8 +1954,10 @@ const file_capiscio_v1_mcp_proto_rawDesc = "" +
 	"envelopeId\x12)\n" +
 	"\x10delegation_depth\x18\f \x01(\x05R\x0fdelegationDepth\x12)\n" +
 	"\x10constraints_json\x18\r \x01(\tR\x0fconstraintsJson\x126\n" +
-	"\x17parent_constraints_json\x18\x0e \x01(\tR\x15parentConstraintsJsonB\x13\n" +
-	"\x11caller_credentialJ\x04\b\t\x10\n" +
+	"\x17parent_constraints_json\x18\x0e \x01(\tR\x15parentConstraintsJson\x126\n" +
+	"\x15deny_on_unknown_class\x18\x0f \x01(\bH\x01R\x12denyOnUnknownClass\x88\x01\x01B\x13\n" +
+	"\x11caller_credentialB\x18\n" +
+	"\x16_deny_on_unknown_classJ\x04\b\t\x10\n" +
 	"\"\xb2\x01\n" +
 	"\x0eEvaluateConfig\x12'\n" +
 	"\x0ftrusted_issuers\x18\x01 \x03(\tR\x0etrustedIssuers\x12&\n" +

--- a/pkg/rpc/gen/capiscio/v1/mcp.pb.go
+++ b/pkg/rpc/gen/capiscio/v1/mcp.pb.go
@@ -354,7 +354,10 @@ type EvaluateToolAccessRequest struct {
 	DelegationDepth       int32  `protobuf:"varint,12,opt,name=delegation_depth,json=delegationDepth,proto3" json:"delegation_depth,omitempty"`                    // reserved for envelope
 	ConstraintsJson       string `protobuf:"bytes,13,opt,name=constraints_json,json=constraintsJson,proto3" json:"constraints_json,omitempty"`                     // reserved for envelope
 	ParentConstraintsJson string `protobuf:"bytes,14,opt,name=parent_constraints_json,json=parentConstraintsJson,proto3" json:"parent_constraints_json,omitempty"` // reserved for envelope
-	// RFC-008: PEP-level unknown capability class behavior (default: deny)
+	// RFC-008: PEP-level unknown capability class behavior.
+	// Proto3 default for bool is false, but the server treats an unset field
+	// as "deny" (fail-closed). Set explicitly to false to allow unknown classes
+	// (e.g. in development/staging environments).
 	DenyOnUnknownClass *bool `protobuf:"varint,15,opt,name=deny_on_unknown_class,json=denyOnUnknownClass,proto3,oneof" json:"deny_on_unknown_class,omitempty"`
 	unknownFields      protoimpl.UnknownFields
 	sizeCache          protoimpl.SizeCache

--- a/proto/capiscio/v1/mcp.proto
+++ b/proto/capiscio/v1/mcp.proto
@@ -80,6 +80,9 @@ message EvaluateToolAccessRequest {
   int32 delegation_depth = 12;          // reserved for envelope
   string constraints_json = 13;         // reserved for envelope
   string parent_constraints_json = 14;  // reserved for envelope
+
+  // RFC-008: PEP-level unknown capability class behavior (default: deny)
+  optional bool deny_on_unknown_class = 15;
 }
 
 // Configuration for tool access evaluation

--- a/proto/capiscio/v1/mcp.proto
+++ b/proto/capiscio/v1/mcp.proto
@@ -81,7 +81,10 @@ message EvaluateToolAccessRequest {
   string constraints_json = 13;         // reserved for envelope
   string parent_constraints_json = 14;  // reserved for envelope
 
-  // RFC-008: PEP-level unknown capability class behavior (default: deny)
+  // RFC-008: PEP-level unknown capability class behavior.
+  // Proto3 default for bool is false, but the server treats an unset field
+  // as "deny" (fail-closed). Set explicitly to false to allow unknown classes
+  // (e.g. in development/staging environments).
   optional bool deny_on_unknown_class = 15;
 }
 


### PR DESCRIPTION
## Summary

Adds RFC-008 §5.5 capability class support to capiscio-core (ALLOW path).

### Changes

- **Policy config** (`pkg/policy/config.go`): Add `CapabilityClassRule` struct with `Class`, `MinTrustLevel`, `AllowedDIDs`, `DeniedDIDs` fields. Dot-notation class name validation via regex.
- **Config validation**: Class name format, trust level values, DID conflict detection, duplicate class detection. 7 test functions with 14+ subtests.
- **PIP types** (`pkg/pip/types.go`): Add `DenyOnUnknownClass *bool` to `DecisionRequest`.
- **OPA client** (`pkg/pdp/opa_client.go`): Wire `DenyOnUnknownClass` into OPA input.
- **Proto** (`proto/capiscio/v1/mcp.proto`): Add field 15 `optional bool deny_on_unknown_class` to `EvaluateToolAccessRequest`.
- **gRPC handler** (`internal/rpc/mcp_service.go`): Wire `CapabilityClass` and `DenyOnUnknownClass` into `EvaluateToolAccessInput`.
- **MCP service** (`pkg/mcp/service.go`): Extend `EvaluateToolAccessInput` with `CapabilityClass` and `DenyOnUnknownClass`.

### Linked PRs
- capiscio-server: `feat/rfc008-capability-class-allow-path`
- capiscio-mcp-python: `feat/rfc008-capability-class-allow-path`
- capiscio-ui: `feat/rfc008-capability-class-allow-path`

### Testing
- All existing tests pass
- New tests: 7 test functions covering parsing, validation, serialization