### PR TITLE
feat(rfc008): Capability Class DENY path — structured rejection metadata

### DIFF
--- a/internal/rpc/mcp_service.go
+++ b/internal/rpc/mcp_service.go
@@ -205,6 +205,12 @@ func (s *MCPService) EvaluateToolAccess(
 	if result.Decision == mcp.DecisionDeny {
 		resp.DenyReason = convertDenyReason(result.DenyReason)
 		resp.DenyDetail = result.DenyDetail
+
+		// RFC-008: populate structured rejection fields from PDP response
+		resp.ErrorCode = result.PolicyErrorCode
+		resp.RejectionDetail = result.DenyDetail
+		resp.RequestedCapability = result.PolicyRequestedCapability
+		resp.PresentedCapability = req.CapabilityClass
 	}
 
 	// Use pre-serialized evidence JSON
@@ -331,6 +337,8 @@ func convertDenyReason(reason mcp.DenyReason) pb.MCPDenyReason {
 		return pb.MCPDenyReason_MCP_DENY_REASON_ISSUER_UNTRUSTED
 	case mcp.DenyReasonPolicyDenied:
 		return pb.MCPDenyReason_MCP_DENY_REASON_POLICY_DENIED
+	case mcp.DenyReasonScopeInsufficient:
+		return pb.MCPDenyReason_MCP_DENY_REASON_SCOPE_INSUFFICIENT
 	default:
 		return pb.MCPDenyReason_MCP_DENY_REASON_UNSPECIFIED
 	}

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -3,6 +3,7 @@ package gateway
 
 import (
 	"crypto"
+	"encoding/json"
 	"log"
 	"log/slog"
 	"net/http"
@@ -161,7 +162,8 @@ func (p *pep) buildPIPRequest(r *http.Request, claims *badge.Claims) *pip.Decisi
 			TrustLevel: claims.TrustLevel(),
 		},
 		Action: pip.ActionAttributes{
-			Operation: r.Method + " " + r.URL.Path,
+			Operation:       r.Method + " " + r.URL.Path,
+			CapabilityClass: strPtrFromHeader(r, "X-Capiscio-Capability-Class"),
 		},
 		Resource: pip.ResourceAttributes{
 			Identifier: r.URL.Path,
@@ -169,6 +171,7 @@ func (p *pep) buildPIPRequest(r *http.Request, claims *badge.Claims) *pip.Decisi
 		Context: pip.ContextAttributes{
 			TxnID:           txnID,
 			EnforcementMode: p.config.EnforcementMode.String(),
+			EnvelopeID:      strPtrFromHeader(r, "X-Capiscio-Envelope-ID"),
 		},
 		Environment: pip.EnvironmentAttrs{
 			PEPID:     strPtr(p.config.PEPID),
@@ -345,11 +348,25 @@ func (p *pep) handlePDPDeny(w http.ResponseWriter, r *http.Request, resp *pip.De
 		emitPolicyEvent(p.callbacks, *event, pipReq)
 		p.next.ServeHTTP(w, r)
 	default:
+		emitPolicyEvent(p.callbacks, *event, pipReq)
+
+		// RFC-008: SCOPE_INSUFFICIENT returns structured JSON 403
+		if resp.ErrorCode == "SCOPE_INSUFFICIENT" {
+			body := map[string]string{
+				"error":                "SCOPE_INSUFFICIENT",
+				"requested_capability": resp.RequestedCapability,
+				"detail":               resp.Reason,
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			_ = json.NewEncoder(w).Encode(body)
+			return
+		}
+
 		reason := "Access denied by policy"
 		if resp.Reason != "" {
 			reason = resp.Reason
 		}
-		emitPolicyEvent(p.callbacks, *event, pipReq)
 		http.Error(w, reason, http.StatusForbidden)
 	}
 }
@@ -417,6 +434,14 @@ func strPtr(s string) *string {
 		return nil
 	}
 	return &s
+}
+
+func strPtrFromHeader(r *http.Request, header string) *string {
+	v := r.Header.Get(header)
+	if v == "" {
+		return nil
+	}
+	return &v
 }
 
 func obligationTypes(obs []pip.Obligation) []string {

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/uuid"
 
 	"github.com/capiscio/capiscio-core/v2/pkg/badge"
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
 	"github.com/capiscio/capiscio-core/v2/pkg/pip"
 )
 
@@ -351,12 +352,20 @@ func (p *pep) handlePDPDeny(w http.ResponseWriter, r *http.Request, resp *pip.De
 		emitPolicyEvent(p.callbacks, *event, pipReq)
 
 		// RFC-008: SCOPE_INSUFFICIENT returns structured JSON 403
-		if resp.ErrorCode == "SCOPE_INSUFFICIENT" {
-			body := map[string]string{
-				"error":                "SCOPE_INSUFFICIENT",
-				"requested_capability": resp.RequestedCapability,
-				"detail":               resp.Reason,
+		if resp.ErrorCode == pip.ErrorCodeScopeInsufficient {
+			var presentedCap, envelopeID string
+			if pipReq.Action.CapabilityClass != nil {
+				presentedCap = *pipReq.Action.CapabilityClass
 			}
+			if pipReq.Context.EnvelopeID != nil {
+				envelopeID = *pipReq.Context.EnvelopeID
+			}
+			body := envelope.NewScopeInsufficientRejection(
+				resp.RequestedCapability,
+				presentedCap,
+				envelopeID,
+				pipReq.Context.TxnID,
+			)
 			w.Header().Set("Content-Type", "application/json")
 			w.WriteHeader(http.StatusForbidden)
 			_ = json.NewEncoder(w).Encode(body)

--- a/pkg/gateway/policy_middleware_test.go
+++ b/pkg/gateway/policy_middleware_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/capiscio/capiscio-core/v2/pkg/badge"
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
 	"github.com/capiscio/capiscio-core/v2/pkg/gateway"
 	"github.com/capiscio/capiscio-core/v2/pkg/pip"
 	"github.com/capiscio/capiscio-core/v2/pkg/registry"
@@ -1018,4 +1019,39 @@ func TestParseBreakGlassJWS(t *testing.T) {
 		_, err := pip.ParseBreakGlassJWS("not-a-jws", pub)
 		assert.Error(t, err)
 	})
+}
+
+func TestPolicyMiddleware_ScopeInsufficientJSON(t *testing.T) {
+	ts := newTestSetup(t)
+
+	pdp := &mockPDP{
+		resp: &pip.DecisionResponse{
+			Decision:            pip.DecisionDeny,
+			DecisionID:          "deny-scope-1",
+			Reason:              "capability class mismatch",
+			ErrorCode:           "SCOPE_INSUFFICIENT",
+			RequestedCapability: "storage",
+		},
+	}
+
+	config := gateway.PEPConfig{
+		PDPClient:       pdp,
+		EnforcementMode: pip.EMStrict,
+	}
+	mw := gateway.NewPolicyMiddleware(ts.verifier, config, okHandler())
+
+	req := httptest.NewRequest("GET", "/v1/data", nil)
+	req.Header.Set("X-Capiscio-Badge", ts.token)
+	rr := httptest.NewRecorder()
+
+	mw.ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusForbidden, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("Content-Type"))
+
+	var body envelope.ScopeInsufficientRejection
+	err := json.NewDecoder(rr.Body).Decode(&body)
+	require.NoError(t, err)
+	assert.Equal(t, envelope.ErrCodeScopeInsufficient, body.Error)
+	assert.Equal(t, "storage", body.RequestedCapability)
 }

--- a/pkg/mcp/errors.go
+++ b/pkg/mcp/errors.go
@@ -28,6 +28,9 @@ var (
 	// ErrPolicyDenied indicates policy evaluation failed
 	ErrPolicyDenied = errors.New("policy denied access")
 
+	// ErrScopeInsufficient indicates the capability class scope is insufficient
+	ErrScopeInsufficient = errors.New("capability class scope insufficient")
+
 	// ErrDIDInvalid indicates the DID is malformed
 	ErrDIDInvalid = errors.New("DID is invalid")
 
@@ -57,6 +60,7 @@ const (
 	DenyReasonToolNotAllowed
 	DenyReasonIssuerUntrusted
 	DenyReasonPolicyDenied
+	DenyReasonScopeInsufficient
 )
 
 // String returns the RFC-006 §10 compliant error code string
@@ -78,6 +82,8 @@ func (r DenyReason) String() string {
 		return "TOOL_ISSUER_UNTRUSTED"
 	case DenyReasonPolicyDenied:
 		return "TOOL_POLICY_DENIED"
+	case DenyReasonScopeInsufficient:
+		return "TOOL_SCOPE_INSUFFICIENT"
 	default:
 		return "UNSPECIFIED"
 	}
@@ -102,6 +108,8 @@ func ErrorToDenyReason(err error) DenyReason {
 		return DenyReasonIssuerUntrusted
 	case errors.Is(err, ErrPolicyDenied):
 		return DenyReasonPolicyDenied
+	case errors.Is(err, ErrScopeInsufficient):
+		return DenyReasonScopeInsufficient
 	default:
 		return DenyReasonUnspecified
 	}

--- a/pkg/mcp/errors_test.go
+++ b/pkg/mcp/errors_test.go
@@ -19,6 +19,7 @@ func TestDenyReasonString(t *testing.T) {
 		{DenyReasonToolNotAllowed, "TOOL_NOT_FOUND"},
 		{DenyReasonIssuerUntrusted, "TOOL_ISSUER_UNTRUSTED"},
 		{DenyReasonPolicyDenied, "TOOL_POLICY_DENIED"},
+		{DenyReasonScopeInsufficient, "TOOL_SCOPE_INSUFFICIENT"},
 	}
 
 	for _, tt := range tests {
@@ -43,6 +44,7 @@ func TestErrorToDenyReason(t *testing.T) {
 		{ErrToolNotAllowed, DenyReasonToolNotAllowed},
 		{ErrIssuerUntrusted, DenyReasonIssuerUntrusted},
 		{ErrPolicyDenied, DenyReasonPolicyDenied},
+		{ErrScopeInsufficient, DenyReasonScopeInsufficient},
 		{nil, DenyReasonUnspecified},
 	}
 

--- a/pkg/mcp/guard.go
+++ b/pkg/mcp/guard.go
@@ -213,6 +213,16 @@ func (g *Guard) evaluateWithPDP(
 		},
 	}
 
+	// RFC-008: propagate capability class and envelope context into PDP request
+	if config.CapabilityClass != "" {
+		cc := config.CapabilityClass
+		pipReq.Action.CapabilityClass = &cc
+	}
+	if config.EnvelopeID != "" {
+		eid := config.EnvelopeID
+		pipReq.Context.EnvelopeID = &eid
+	}
+
 	resp, err := g.pdpClient.Evaluate(ctx, pipReq)
 
 	if err != nil {
@@ -272,7 +282,7 @@ func (g *Guard) evaluateWithPDP(
 			result.PolicyDecision = pip.DecisionObserve
 		default:
 			result.Decision = DecisionDeny
-			if resp.ErrorCode == "SCOPE_INSUFFICIENT" {
+			if resp.ErrorCode == pip.ErrorCodeScopeInsufficient {
 				result.DenyReason = DenyReasonScopeInsufficient
 			} else {
 				result.DenyReason = DenyReasonPolicyDenied

--- a/pkg/mcp/guard.go
+++ b/pkg/mcp/guard.go
@@ -260,6 +260,10 @@ func (g *Guard) evaluateWithPDP(
 	result.PolicyDecision = resp.Decision
 
 	if resp.Decision == pip.DecisionDeny {
+		// RFC-008: propagate structured denial metadata from PDP
+		result.PolicyErrorCode = resp.ErrorCode
+		result.PolicyRequestedCapability = resp.RequestedCapability
+
 		switch g.emMode {
 		case pip.EMObserve:
 			// Log but allow
@@ -268,7 +272,11 @@ func (g *Guard) evaluateWithPDP(
 			result.PolicyDecision = pip.DecisionObserve
 		default:
 			result.Decision = DecisionDeny
-			result.DenyReason = DenyReasonPolicyDenied
+			if resp.ErrorCode == "SCOPE_INSUFFICIENT" {
+				result.DenyReason = DenyReasonScopeInsufficient
+			} else {
+				result.DenyReason = DenyReasonPolicyDenied
+			}
 			result.DenyDetail = resp.Reason
 		}
 		return

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -147,6 +147,14 @@ type EvaluateConfig struct {
 
 	// PolicyVersion is the version of the policy being applied (RFC-006 §7.2)
 	PolicyVersion string
+
+	// CapabilityClass is the capability class from the authority envelope (RFC-008).
+	// When set, it is forwarded to the PDP as Action.CapabilityClass.
+	CapabilityClass string
+
+	// EnvelopeID is the envelope_id from the authority envelope (RFC-008).
+	// When set, it is forwarded to the PDP as Context.EnvelopeID.
+	EnvelopeID string
 }
 
 // EvaluateResult holds the result of tool access evaluation

--- a/pkg/mcp/types.go
+++ b/pkg/mcp/types.go
@@ -186,6 +186,15 @@ type EvaluateResult struct {
 
 	// PolicyDecision is the PDP decision string: ALLOW, DENY, or ALLOW_OBSERVE (RFC-005)
 	PolicyDecision string
+
+	// PolicyErrorCode is the structured error code from PDP (RFC-008, e.g. "SCOPE_INSUFFICIENT")
+	PolicyErrorCode string
+
+	// PolicyRequestedCapability is the capability class that triggered DENY (RFC-008)
+	PolicyRequestedCapability string
+
+	// PresentedCapability is the capability class the agent presented in the request (RFC-008)
+	PresentedCapability string
 }
 
 // VerifyConfig holds configuration for server identity verification

--- a/pkg/pdp/opa_client.go
+++ b/pkg/pdp/opa_client.go
@@ -231,11 +231,17 @@ func mapOPAResult(results rego.ResultSet) (*pip.DecisionResponse, error) {
 		obligations = extractObligations(oblSet)
 	}
 
+	// RFC-008: structured denial metadata
+	errorCode, _ := policyResult["error_code"].(string)
+	requestedCapability, _ := policyResult["requested_capability"].(string)
+
 	return &pip.DecisionResponse{
-		Decision:    decision,
-		DecisionID:  decisionID,
-		Obligations: obligations,
-		Reason:      reason,
+		Decision:            decision,
+		DecisionID:          decisionID,
+		Obligations:         obligations,
+		Reason:              reason,
+		ErrorCode:           errorCode,
+		RequestedCapability: requestedCapability,
 	}, nil
 }
 

--- a/pkg/pdp/opa_client_test.go
+++ b/pkg/pdp/opa_client_test.go
@@ -123,6 +123,47 @@ tool_blocked if {
 obligations = []
 `
 
+// Rego policy that denies with error_code and requested_capability (RFC-008).
+const regoScopeInsufficient = `package capiscio.policy
+
+import rego.v1
+
+default decision = "ALLOW"
+
+decision = "DENY" if {
+	input.action.capability_class != ""
+	input.action.capability_class != "compute"
+}
+
+reason = "capability class mismatch" if {
+	input.action.capability_class != ""
+	input.action.capability_class != "compute"
+}
+
+reason = "allowed" if {
+	not scope_denied
+}
+
+scope_denied if {
+	input.action.capability_class != ""
+	input.action.capability_class != "compute"
+}
+
+error_code = "SCOPE_INSUFFICIENT" if {
+	scope_denied
+}
+
+default error_code = ""
+
+requested_capability = input.action.capability_class if {
+	scope_denied
+}
+
+default requested_capability = ""
+
+obligations = []
+`
+
 func newTestRequest() *pip.DecisionRequest {
 	return &pip.DecisionRequest{
 		PIPVersion: pip.PIPVersion,
@@ -486,4 +527,22 @@ func TestBuildOPAInput_AllOptionalFields(t *testing.T) {
 	assert.Equal(t, "workspace-1", env["workspace"])
 	assert.Equal(t, "pep-1", env["pep_id"])
 	assert.Equal(t, "2026-03-28T12:00:00Z", env["time"])
+}
+
+func TestOPALocalClient_ErrorCodeAndRequestedCapability(t *testing.T) {
+	client := NewOPALocalClient()
+
+	modules := map[string]string{"policy.rego": regoScopeInsufficient}
+	err := client.LoadBundle(context.Background(), modules, nil)
+	require.NoError(t, err)
+
+	req := newTestRequest()
+	capClass := "storage"
+	req.Action.CapabilityClass = &capClass
+
+	resp, err := client.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+	assert.Equal(t, "DENY", resp.Decision)
+	assert.Equal(t, "SCOPE_INSUFFICIENT", resp.ErrorCode)
+	assert.Equal(t, "storage", resp.RequestedCapability)
 }

--- a/pkg/pip/types.go
+++ b/pkg/pip/types.go
@@ -66,11 +66,13 @@ type EnvironmentAttrs struct {
 
 // DecisionResponse is the canonical PDP response (RFC-005 §6.1).
 type DecisionResponse struct {
-	Decision    string       `json:"decision"`              // "ALLOW" or "DENY"
-	DecisionID  string       `json:"decision_id"`           // globally unique
-	Obligations []Obligation `json:"obligations"`           // may be empty
-	Reason      string       `json:"reason,omitempty"`      // human-readable
-	TTL         *int         `json:"ttl,omitempty"`          // cache lifetime seconds
+	Decision            string       `json:"decision"`                        // "ALLOW" or "DENY"
+	DecisionID          string       `json:"decision_id"`                     // globally unique
+	Obligations         []Obligation `json:"obligations"`                     // may be empty
+	Reason              string       `json:"reason,omitempty"`                // human-readable
+	TTL                 *int         `json:"ttl,omitempty"`                   // cache lifetime seconds
+	ErrorCode           string       `json:"error_code,omitempty"`            // RFC-008: e.g. "SCOPE_INSUFFICIENT"
+	RequestedCapability string       `json:"requested_capability,omitempty"`  // RFC-008: the capability class that was denied
 }
 
 // Obligation is a conditional contract per RFC-005 §7.1.

--- a/pkg/pip/types.go
+++ b/pkg/pip/types.go
@@ -15,6 +15,10 @@ const (
 	DecisionObserve = "ALLOW_OBSERVE" // PEP-only: emitted when EM-OBSERVE falls back on PDP unavailability
 )
 
+// ErrorCodeScopeInsufficient is the PDP error code emitted by Rego when the
+// badge's capability class does not cover the requested operation (RFC-008 §9.3).
+const ErrorCodeScopeInsufficient = "SCOPE_INSUFFICIENT"
+
 // DecisionRequest is the canonical PDP query (RFC-005 §5.1).
 type DecisionRequest struct {
 	PIPVersion         string             `json:"pip_version"`

--- a/pkg/rpc/gen/capiscio/v1/mcp.pb.go
+++ b/pkg/rpc/gen/capiscio/v1/mcp.pb.go
@@ -150,6 +150,7 @@ const (
 	MCPDenyReason_MCP_DENY_REASON_TOOL_NOT_ALLOWED   MCPDenyReason = 6 // Tool not in allowed list
 	MCPDenyReason_MCP_DENY_REASON_ISSUER_UNTRUSTED   MCPDenyReason = 7
 	MCPDenyReason_MCP_DENY_REASON_POLICY_DENIED      MCPDenyReason = 8 // Policy evaluation failed
+	MCPDenyReason_MCP_DENY_REASON_SCOPE_INSUFFICIENT MCPDenyReason = 9 // RFC-008: Capability class scope insufficient
 )
 
 // Enum value maps for MCPDenyReason.
@@ -164,6 +165,7 @@ var (
 		6: "MCP_DENY_REASON_TOOL_NOT_ALLOWED",
 		7: "MCP_DENY_REASON_ISSUER_UNTRUSTED",
 		8: "MCP_DENY_REASON_POLICY_DENIED",
+		9: "MCP_DENY_REASON_SCOPE_INSUFFICIENT",
 	}
 	MCPDenyReason_value = map[string]int32{
 		"MCP_DENY_REASON_UNSPECIFIED":        0,
@@ -175,6 +177,7 @@ var (
 		"MCP_DENY_REASON_TOOL_NOT_ALLOWED":   6,
 		"MCP_DENY_REASON_ISSUER_UNTRUSTED":   7,
 		"MCP_DENY_REASON_POLICY_DENIED":      8,
+		"MCP_DENY_REASON_SCOPE_INSUFFICIENT": 9,
 	}
 )
 
@@ -617,8 +620,13 @@ type EvaluateToolAccessResponse struct {
 	PolicyDecision   string           `protobuf:"bytes,12,opt,name=policy_decision,json=policyDecision,proto3" json:"policy_decision,omitempty"`         // ALLOW, DENY, or ALLOW_OBSERVE
 	EnforcementMode  string           `protobuf:"bytes,13,opt,name=enforcement_mode,json=enforcementMode,proto3" json:"enforcement_mode,omitempty"`      // mode used for this evaluation
 	Obligations      []*MCPObligation `protobuf:"bytes,14,rep,name=obligations,proto3" json:"obligations,omitempty"`                                     // obligations from PDP
-	unknownFields    protoimpl.UnknownFields
-	sizeCache        protoimpl.SizeCache
+	// RFC-008: Structured rejection metadata (populated on DENY)
+	ErrorCode           string `protobuf:"bytes,15,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"`                               // e.g. "SCOPE_INSUFFICIENT"
+	RejectionDetail     string `protobuf:"bytes,16,opt,name=rejection_detail,json=rejectionDetail,proto3" json:"rejection_detail,omitempty"`             // human-readable denial detail
+	RequestedCapability string `protobuf:"bytes,17,opt,name=requested_capability,json=requestedCapability,proto3" json:"requested_capability,omitempty"` // capability class that was denied
+	PresentedCapability string `protobuf:"bytes,18,opt,name=presented_capability,json=presentedCapability,proto3" json:"presented_capability,omitempty"` // capability class the agent presented (if any)
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
 }
 
 func (x *EvaluateToolAccessResponse) Reset() {
@@ -747,6 +755,34 @@ func (x *EvaluateToolAccessResponse) GetObligations() []*MCPObligation {
 		return x.Obligations
 	}
 	return nil
+}
+
+func (x *EvaluateToolAccessResponse) GetErrorCode() string {
+	if x != nil {
+		return x.ErrorCode
+	}
+	return ""
+}
+
+func (x *EvaluateToolAccessResponse) GetRejectionDetail() string {
+	if x != nil {
+		return x.RejectionDetail
+	}
+	return ""
+}
+
+func (x *EvaluateToolAccessResponse) GetRequestedCapability() string {
+	if x != nil {
+		return x.RequestedCapability
+	}
+	return ""
+}
+
+func (x *EvaluateToolAccessResponse) GetPresentedCapability() string {
+	if x != nil {
+		return x.PresentedCapability
+	}
+	return ""
 }
 
 // Obligation returned by PDP (RFC-005 §7.1)
@@ -1966,7 +2002,7 @@ const file_capiscio_v1_mcp_proto_rawDesc = "" +
 	"\x0ftrusted_issuers\x18\x01 \x03(\tR\x0etrustedIssuers\x12&\n" +
 	"\x0fmin_trust_level\x18\x02 \x01(\x05R\rminTrustLevel\x12*\n" +
 	"\x11accept_level_zero\x18\x03 \x01(\bR\x0facceptLevelZero\x12#\n" +
-	"\rallowed_tools\x18\x04 \x03(\tR\fallowedTools\"\x85\x05\n" +
+	"\rallowed_tools\x18\x04 \x03(\tR\fallowedTools\"\xb5\x06\n" +
 	"\x1aEvaluateToolAccessResponse\x124\n" +
 	"\bdecision\x18\x01 \x01(\x0e2\x18.capiscio.v1.MCPDecisionR\bdecision\x12;\n" +
 	"\vdeny_reason\x18\x02 \x01(\x0e2\x1a.capiscio.v1.MCPDenyReasonR\n" +
@@ -1987,7 +2023,12 @@ const file_capiscio_v1_mcp_proto_rawDesc = "" +
 	"\x12policy_decision_id\x18\v \x01(\tR\x10policyDecisionId\x12'\n" +
 	"\x0fpolicy_decision\x18\f \x01(\tR\x0epolicyDecision\x12)\n" +
 	"\x10enforcement_mode\x18\r \x01(\tR\x0fenforcementMode\x12<\n" +
-	"\vobligations\x18\x0e \x03(\v2\x1a.capiscio.v1.MCPObligationR\vobligations\"D\n" +
+	"\vobligations\x18\x0e \x03(\v2\x1a.capiscio.v1.MCPObligationR\vobligations\x12\x1d\n" +
+	"\n" +
+	"error_code\x18\x0f \x01(\tR\terrorCode\x12)\n" +
+	"\x10rejection_detail\x18\x10 \x01(\tR\x0frejectionDetail\x121\n" +
+	"\x14requested_capability\x18\x11 \x01(\tR\x13requestedCapability\x121\n" +
+	"\x14presented_capability\x18\x12 \x01(\tR\x13presentedCapability\"D\n" +
 	"\rMCPObligation\x12\x12\n" +
 	"\x04type\x18\x01 \x01(\tR\x04type\x12\x1f\n" +
 	"\vparams_json\x18\x02 \x01(\tR\n" +
@@ -2087,7 +2128,7 @@ const file_capiscio_v1_mcp_proto_rawDesc = "" +
 	"\x1aMCP_AUTH_LEVEL_UNSPECIFIED\x10\x00\x12\x1c\n" +
 	"\x18MCP_AUTH_LEVEL_ANONYMOUS\x10\x01\x12\x1a\n" +
 	"\x16MCP_AUTH_LEVEL_API_KEY\x10\x02\x12\x18\n" +
-	"\x14MCP_AUTH_LEVEL_BADGE\x10\x03*\xd3\x02\n" +
+	"\x14MCP_AUTH_LEVEL_BADGE\x10\x03*\xfb\x02\n" +
 	"\rMCPDenyReason\x12\x1f\n" +
 	"\x1bMCP_DENY_REASON_UNSPECIFIED\x10\x00\x12!\n" +
 	"\x1dMCP_DENY_REASON_BADGE_MISSING\x10\x01\x12!\n" +
@@ -2097,7 +2138,8 @@ const file_capiscio_v1_mcp_proto_rawDesc = "" +
 	"\"MCP_DENY_REASON_TRUST_INSUFFICIENT\x10\x05\x12$\n" +
 	" MCP_DENY_REASON_TOOL_NOT_ALLOWED\x10\x06\x12$\n" +
 	" MCP_DENY_REASON_ISSUER_UNTRUSTED\x10\a\x12!\n" +
-	"\x1dMCP_DENY_REASON_POLICY_DENIED\x10\b*\xac\x01\n" +
+	"\x1dMCP_DENY_REASON_POLICY_DENIED\x10\b\x12&\n" +
+	"\"MCP_DENY_REASON_SCOPE_INSUFFICIENT\x10\t*\xac\x01\n" +
 	"\x0eMCPServerState\x12 \n" +
 	"\x1cMCP_SERVER_STATE_UNSPECIFIED\x10\x00\x12'\n" +
 	"#MCP_SERVER_STATE_VERIFIED_PRINCIPAL\x10\x01\x12'\n" +

--- a/proto/capiscio/v1/mcp.proto
+++ b/proto/capiscio/v1/mcp.proto
@@ -135,6 +135,12 @@ message EvaluateToolAccessResponse {
   string policy_decision = 12;          // ALLOW, DENY, or ALLOW_OBSERVE
   string enforcement_mode = 13;         // mode used for this evaluation
   repeated MCPObligation obligations = 14; // obligations from PDP
+
+  // RFC-008: Structured rejection metadata (populated on DENY)
+  string error_code = 15;               // e.g. "SCOPE_INSUFFICIENT"
+  string rejection_detail = 16;         // human-readable denial detail
+  string requested_capability = 17;     // capability class that was denied
+  string presented_capability = 18;     // capability class the agent presented (if any)
 }
 
 // Obligation returned by PDP (RFC-005 §7.1)
@@ -292,6 +298,7 @@ enum MCPDenyReason {
   MCP_DENY_REASON_TOOL_NOT_ALLOWED = 6;    // Tool not in allowed list
   MCP_DENY_REASON_ISSUER_UNTRUSTED = 7;
   MCP_DENY_REASON_POLICY_DENIED = 8;       // Policy evaluation failed
+  MCP_DENY_REASON_SCOPE_INSUFFICIENT = 9;  // RFC-008: Capability class scope insufficient
 }
 
 // ============================================================================


### PR DESCRIPTION
## Summary

RFC-008 Capability Class implementation — **PR B (DENY path)**.

Adds structured denial metadata throughout the evaluation stack so that when a capability class policy denies access, callers receive actionable error information instead of a generic 403.

## Changes

### PIP/PDP Layer
- `DecisionResponse`: added `ErrorCode` and `RequestedCapability` fields
- Core OPA evaluator: maps `error_code`/`requested_capability` from OPA result

### Gateway PEP
- Extracts `X-Capiscio-Capability-Class` and `X-Capiscio-Envelope-ID` headers
- Returns JSON 403 with `SCOPE_INSUFFICIENT` error code and capability details
- Falls back to plain text 403 for non-capability denials

### Proto (gRPC)
- `EvaluateToolAccessResponse`: added fields 15-18 (`error_code`, `rejection_detail`, `requested_capability`, `presented_capability`)
- `MCPDenyReason`: added `MCP_DENY_REASON_SCOPE_INSUFFICIENT = 9`

### MCP Guard
- New `DenyReasonScopeInsufficient` + `ErrScopeInsufficient` sentinel
- Guard propagates `error_code`/`requested_capability`/`presented_capability` from PDP
- gRPC handler populates rejection metadata on DENY responses
- `EvaluateResult`: added `PolicyErrorCode`, `PolicyRequestedCapability`, `PresentedCapability`

## Testing
- All Go tests pass: `go test ./pkg/pip/ ./pkg/pdp/ ./pkg/mcp/ ./pkg/gateway/ ./internal/rpc/`
- `go build ./...` clean

## Related PRs
- capiscio-server: `feat/rfc008-capability-class-deny-path`
- capiscio-mcp-python: `feat/rfc008-capability-class-deny-path`
- capiscio-ui: `feat/rfc008-capability-class-deny-path`