### PR TITLE
feat(rpc): add envelope gRPC surface for RFC-008 delegation chain

### DIFF
--- a/internal/rpc/simpleguard_envelope.go
+++ b/internal/rpc/simpleguard_envelope.go
@@ -82,7 +82,7 @@ func (s *SimpleGuardService) CreateEnvelope(_ context.Context, req *pb.CreateEnv
 		payload.EnforcementModeMin = &req.EnforcementModeMin
 	}
 
-	jws, err := envelope.SignEnvelope(payload, entry.PrivateKey, req.KeyId)
+	jws, err := envelope.SignEnvelope(payload, entry.PrivateKey, issuerDID+"#"+req.KeyId)
 	if err != nil {
 		return &pb.CreateEnvelopeResponse{ErrorMessage: fmt.Sprintf("sign failed: %v", err)}, nil
 	}
@@ -143,10 +143,20 @@ func (s *SimpleGuardService) DeriveEnvelope(_ context.Context, req *pb.DeriveEnv
 		childPayload.Constraints = map[string]any{}
 	}
 
-	// Enforcement mode: inherit parent's minimum, allow escalation but not relaxation
+	// Enforcement mode: inherit parent's minimum, allow escalation but not relaxation (RFC-008 §10.5)
 	if req.EnforcementModeMin != "" {
-		if _, err := envelope.ParseEnforcementMode(req.EnforcementModeMin); err != nil {
+		childMode, err := envelope.ParseEnforcementMode(req.EnforcementModeMin)
+		if err != nil {
 			return &pb.DeriveEnvelopeResponse{ErrorMessage: fmt.Sprintf("invalid enforcement mode: %v", err)}, nil
+		}
+		// Reject if child mode is less strict than parent's minimum
+		if parent.Payload.EnforcementModeMin != nil {
+			parentMode, _ := envelope.ParseEnforcementMode(*parent.Payload.EnforcementModeMin)
+			if childMode < parentMode {
+				return &pb.DeriveEnvelopeResponse{
+					ErrorMessage: fmt.Sprintf("enforcement_mode_min %q is less strict than parent's %q; relaxation is not permitted", req.EnforcementModeMin, *parent.Payload.EnforcementModeMin),
+				}, nil
+			}
 		}
 		childPayload.EnforcementModeMin = &req.EnforcementModeMin
 	} else if parent.Payload.EnforcementModeMin != nil {
@@ -154,7 +164,7 @@ func (s *SimpleGuardService) DeriveEnvelope(_ context.Context, req *pb.DeriveEnv
 	}
 
 	// DeriveEnvelope handles: hash linking, narrowing validation, depth check
-	jws, err := envelope.DeriveEnvelope(parent, childPayload, entry.PrivateKey, req.KeyId)
+	jws, err := envelope.DeriveEnvelope(parent, childPayload, entry.PrivateKey, issuerDID+"#"+req.KeyId)
 	if err != nil {
 		return &pb.DeriveEnvelopeResponse{ErrorMessage: fmt.Sprintf("derive failed: %v", err)}, nil
 	}
@@ -218,15 +228,23 @@ func (s *SimpleGuardService) VerifyEnvelopeChain(ctx context.Context, req *pb.Ve
 	}
 
 	opts := envelope.VerifyOptions{
-		TrustedIssuers:        req.TrustedIssuers,
-		SkipBadgeVerification: true, // badge verification is separate (PEP handles it)
+		TrustedIssuers: req.TrustedIssuers,
+		// SkipBadgeVerification is true because badge verification is the
+		// PEP's responsibility (it validates the caller's badge separately).
+		// Chain verification only validates envelope signatures and structure.
+		SkipBadgeVerification: true,
 	}
 
 	if req.EnforcementMode != "" {
 		em, err := envelope.ParseEnforcementMode(req.EnforcementMode)
-		if err == nil {
-			opts.EnforcementMode = em
+		if err != nil {
+			return &pb.VerifyEnvelopeChainResponse{
+				Valid:        false,
+				ErrorCode:    envelope.ErrCodeMalformed,
+				ErrorMessage: fmt.Sprintf("invalid enforcement_mode: %v", err),
+			}, nil
 		}
+		opts.EnforcementMode = em
 	}
 
 	result, err := verifier.VerifyChain(ctx, req.Chain, req.BadgeMap, opts)

--- a/internal/rpc/simpleguard_envelope.go
+++ b/internal/rpc/simpleguard_envelope.go
@@ -1,0 +1,267 @@
+package rpc
+
+import (
+	"context"
+	"crypto/ed25519"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/capiscio/capiscio-core/v2/pkg/did"
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
+	pb "github.com/capiscio/capiscio-core/v2/pkg/rpc/gen/capiscio/v1"
+)
+
+// ptrStr returns a pointer to s.
+func ptrStr(s string) *string { return &s }
+
+// ptrIfNotEmpty returns nil if s is empty, otherwise &s.
+func ptrIfNotEmpty(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
+}
+
+// CreateEnvelope creates a root Authority Envelope (RFC-008 §6.1).
+func (s *SimpleGuardService) CreateEnvelope(_ context.Context, req *pb.CreateEnvelopeRequest) (*pb.CreateEnvelopeResponse, error) {
+	s.mu.RLock()
+	entry, exists := s.keys[req.KeyId]
+	s.mu.RUnlock()
+
+	if !exists {
+		return &pb.CreateEnvelopeResponse{ErrorMessage: fmt.Sprintf("key not found: %s", req.KeyId)}, nil
+	}
+	if entry.PrivateKey == nil {
+		return &pb.CreateEnvelopeResponse{ErrorMessage: fmt.Sprintf("no private key for: %s", req.KeyId)}, nil
+	}
+
+	now := time.Now()
+	expiresIn := time.Duration(req.ExpiresInSeconds) * time.Second
+	if expiresIn == 0 {
+		expiresIn = time.Hour
+	}
+
+	issuerDID := did.NewKeyDID(ed25519.PublicKey(entry.PublicKey))
+	envelopeID := uuid.New().String()
+	txnID := req.TxnId
+	if txnID == "" {
+		txnID = uuid.New().String()
+	}
+
+	payload := &envelope.Payload{
+		EnvelopeID:               envelopeID,
+		IssuerDID:                issuerDID,
+		SubjectDID:               req.SubjectDid,
+		TxnID:                    txnID,
+		CapabilityClass:          req.CapabilityClass,
+		DelegationDepthRemaining: int(req.DelegationDepthRemaining),
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(expiresIn).Unix(),
+		IssuerBadgeJTI:           req.IssuerBadgeJti,
+		SubjectBadgeJTI:          ptrIfNotEmpty(req.SubjectBadgeJti),
+	}
+
+	// Parse optional constraints JSON
+	if req.ConstraintsJson != "" {
+		var constraints map[string]any
+		if err := json.Unmarshal([]byte(req.ConstraintsJson), &constraints); err != nil {
+			return &pb.CreateEnvelopeResponse{ErrorMessage: fmt.Sprintf("invalid constraints JSON: %v", err)}, nil
+		}
+		payload.Constraints = constraints
+	} else {
+		payload.Constraints = map[string]any{}
+	}
+
+	// Validate and set optional enforcement mode
+	if req.EnforcementModeMin != "" {
+		if _, err := envelope.ParseEnforcementMode(req.EnforcementModeMin); err != nil {
+			return &pb.CreateEnvelopeResponse{ErrorMessage: fmt.Sprintf("invalid enforcement mode: %v", err)}, nil
+		}
+		payload.EnforcementModeMin = &req.EnforcementModeMin
+	}
+
+	jws, err := envelope.SignEnvelope(payload, entry.PrivateKey, req.KeyId)
+	if err != nil {
+		return &pb.CreateEnvelopeResponse{ErrorMessage: fmt.Sprintf("sign failed: %v", err)}, nil
+	}
+
+	return &pb.CreateEnvelopeResponse{
+		EnvelopeJws: jws,
+		EnvelopeId:  envelopeID,
+		IssuerDid:   issuerDID,
+	}, nil
+}
+
+// DeriveEnvelope derives a child Authority Envelope from a parent (RFC-008 §6.3).
+func (s *SimpleGuardService) DeriveEnvelope(_ context.Context, req *pb.DeriveEnvelopeRequest) (*pb.DeriveEnvelopeResponse, error) {
+	s.mu.RLock()
+	entry, exists := s.keys[req.KeyId]
+	s.mu.RUnlock()
+
+	if !exists {
+		return &pb.DeriveEnvelopeResponse{ErrorMessage: fmt.Sprintf("key not found: %s", req.KeyId)}, nil
+	}
+	if entry.PrivateKey == nil {
+		return &pb.DeriveEnvelopeResponse{ErrorMessage: fmt.Sprintf("no private key for: %s", req.KeyId)}, nil
+	}
+
+	// Parse parent envelope
+	parent, err := envelope.ParseToken(req.ParentEnvelopeJws)
+	if err != nil {
+		return &pb.DeriveEnvelopeResponse{ErrorMessage: fmt.Sprintf("invalid parent envelope: %v", err)}, nil
+	}
+
+	issuerDID := did.NewKeyDID(ed25519.PublicKey(entry.PublicKey))
+	now := time.Now()
+	expiresIn := time.Duration(req.ExpiresInSeconds) * time.Second
+	if expiresIn == 0 {
+		expiresIn = 30 * time.Minute
+	}
+
+	childPayload := &envelope.Payload{
+		EnvelopeID:               uuid.New().String(),
+		IssuerDID:                issuerDID,
+		SubjectDID:               req.SubjectDid,
+		TxnID:                    parent.Payload.TxnID,
+		CapabilityClass:          req.CapabilityClass,
+		DelegationDepthRemaining: int(req.DelegationDepthRemaining),
+		IssuedAt:                 now.Unix(),
+		ExpiresAt:                now.Add(expiresIn).Unix(),
+		IssuerBadgeJTI:           req.IssuerBadgeJti,
+		SubjectBadgeJTI:          ptrIfNotEmpty(req.SubjectBadgeJti),
+	}
+
+	if req.ConstraintsJson != "" {
+		var constraints map[string]any
+		if err := json.Unmarshal([]byte(req.ConstraintsJson), &constraints); err != nil {
+			return &pb.DeriveEnvelopeResponse{ErrorMessage: fmt.Sprintf("invalid constraints JSON: %v", err)}, nil
+		}
+		childPayload.Constraints = constraints
+	} else {
+		childPayload.Constraints = map[string]any{}
+	}
+
+	// Enforcement mode: inherit parent's minimum, allow escalation but not relaxation
+	if req.EnforcementModeMin != "" {
+		if _, err := envelope.ParseEnforcementMode(req.EnforcementModeMin); err != nil {
+			return &pb.DeriveEnvelopeResponse{ErrorMessage: fmt.Sprintf("invalid enforcement mode: %v", err)}, nil
+		}
+		childPayload.EnforcementModeMin = &req.EnforcementModeMin
+	} else if parent.Payload.EnforcementModeMin != nil {
+		childPayload.EnforcementModeMin = parent.Payload.EnforcementModeMin
+	}
+
+	// DeriveEnvelope handles: hash linking, narrowing validation, depth check
+	jws, err := envelope.DeriveEnvelope(parent, childPayload, entry.PrivateKey, req.KeyId)
+	if err != nil {
+		return &pb.DeriveEnvelopeResponse{ErrorMessage: fmt.Sprintf("derive failed: %v", err)}, nil
+	}
+
+	var parentHash string
+	if childPayload.ParentAuthorityHash != nil {
+		parentHash = *childPayload.ParentAuthorityHash
+	}
+
+	return &pb.DeriveEnvelopeResponse{
+		EnvelopeJws:         jws,
+		EnvelopeId:          childPayload.EnvelopeID,
+		ParentAuthorityHash: parentHash,
+	}, nil
+}
+
+// BuildTransportHeaders builds HTTP transport headers for a delegation chain (RFC-008 §15).
+func (s *SimpleGuardService) BuildTransportHeaders(_ context.Context, req *pb.BuildTransportHeadersRequest) (*pb.BuildTransportHeadersResponse, error) {
+	if len(req.Chain) == 0 {
+		return &pb.BuildTransportHeadersResponse{ErrorMessage: "chain must not be empty"}, nil
+	}
+
+	leaf := req.Chain[len(req.Chain)-1]
+
+	// Encode chain as base64url(JSON array)
+	chainJSON, err := json.Marshal(req.Chain)
+	if err != nil {
+		return &pb.BuildTransportHeadersResponse{ErrorMessage: fmt.Sprintf("marshal chain: %v", err)}, nil
+	}
+	chainEncoded := base64.RawURLEncoding.EncodeToString(chainJSON)
+
+	// Encode badge map as base64url(JSON object)
+	var badgeMapEncoded string
+	if len(req.BadgeMap) > 0 {
+		bmJSON, err := json.Marshal(req.BadgeMap)
+		if err != nil {
+			return &pb.BuildTransportHeadersResponse{ErrorMessage: fmt.Sprintf("marshal badge map: %v", err)}, nil
+		}
+		badgeMapEncoded = base64.RawURLEncoding.EncodeToString(bmJSON)
+	}
+
+	return &pb.BuildTransportHeadersResponse{
+		AuthorityHeader:      leaf,
+		AuthorityChainHeader: chainEncoded,
+		BadgeMapHeader:       badgeMapEncoded,
+	}, nil
+}
+
+// VerifyEnvelopeChain verifies an Authority Envelope chain (RFC-008 §9.2).
+func (s *SimpleGuardService) VerifyEnvelopeChain(ctx context.Context, req *pb.VerifyEnvelopeChainRequest) (*pb.VerifyEnvelopeChainResponse, error) {
+	if len(req.Chain) == 0 {
+		return &pb.VerifyEnvelopeChainResponse{
+			Valid:        false,
+			ErrorCode:    envelope.ErrCodeMalformed,
+			ErrorMessage: "chain is empty",
+		}, nil
+	}
+
+	verifier := &envelope.Verifier{
+		KeyResolver: envelope.DefaultKeyResolver,
+	}
+
+	opts := envelope.VerifyOptions{
+		TrustedIssuers:        req.TrustedIssuers,
+		SkipBadgeVerification: true, // badge verification is separate (PEP handles it)
+	}
+
+	if req.EnforcementMode != "" {
+		em, err := envelope.ParseEnforcementMode(req.EnforcementMode)
+		if err == nil {
+			opts.EnforcementMode = em
+		}
+	}
+
+	result, err := verifier.VerifyChain(ctx, req.Chain, req.BadgeMap, opts)
+	if err != nil {
+		var envErr *envelope.Error
+		if errors.As(err, &envErr) {
+			return &pb.VerifyEnvelopeChainResponse{
+				Valid:        false,
+				ErrorCode:    envErr.Code,
+				ErrorMessage: envErr.Message,
+			}, nil
+		}
+		return &pb.VerifyEnvelopeChainResponse{
+			Valid:        false,
+			ErrorMessage: fmt.Sprintf("verification failed: %v", err),
+		}, nil
+	}
+
+	// Extract leaf info
+	var leafIssuerDID, leafSubjectDID string
+	if len(result.Links) > 0 {
+		leafLink := result.Links[len(result.Links)-1]
+		leafIssuerDID = leafLink.Payload.IssuerDID
+		leafSubjectDID = leafLink.Payload.SubjectDID
+	}
+
+	return &pb.VerifyEnvelopeChainResponse{
+		Valid:          true,
+		RootCapability: result.RootCapability,
+		LeafCapability: result.LeafCapability,
+		TotalDepth:     int32(result.TotalDepth),
+		LeafIssuerDid:  leafIssuerDID,
+		LeafSubjectDid: leafSubjectDID,
+	}, nil
+}

--- a/internal/rpc/simpleguard_envelope.go
+++ b/internal/rpc/simpleguard_envelope.go
@@ -16,9 +16,6 @@ import (
 	pb "github.com/capiscio/capiscio-core/v2/pkg/rpc/gen/capiscio/v1"
 )
 
-// ptrStr returns a pointer to s.
-func ptrStr(s string) *string { return &s }
-
 // ptrIfNotEmpty returns nil if s is empty, otherwise &s.
 func ptrIfNotEmpty(s string) *string {
 	if s == "" {

--- a/internal/rpc/simpleguard_envelope_test.go
+++ b/internal/rpc/simpleguard_envelope_test.go
@@ -1,0 +1,257 @@
+package rpc
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/capiscio/capiscio-core/v2/pkg/envelope"
+	pb "github.com/capiscio/capiscio-core/v2/pkg/rpc/gen/capiscio/v1"
+)
+
+func newTestSimpleGuardService(t *testing.T) *SimpleGuardService {
+	t.Helper()
+	return NewSimpleGuardService()
+}
+
+var ctx = context.Background()
+
+func TestCreateEnvelope_Basic(t *testing.T) {
+	svc := newTestSimpleGuardService(t)
+	genResp, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+
+	resp, err := svc.CreateEnvelope(ctx, &pb.CreateEnvelopeRequest{
+		KeyId:                    genResp.KeyId,
+		SubjectDid:               "did:key:z6MkTest",
+		CapabilityClass:          "tools.database.read",
+		DelegationDepthRemaining: 3,
+		IssuerBadgeJti:           "badge-123",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.ErrorMessage)
+	assert.NotEmpty(t, resp.EnvelopeJws)
+	assert.NotEmpty(t, resp.EnvelopeId)
+
+	// Verify the JWS can be parsed back
+	token, err := envelope.ParseToken(resp.EnvelopeJws)
+	require.NoError(t, err)
+	assert.Equal(t, "tools.database.read", token.Payload.CapabilityClass)
+	assert.Equal(t, 3, token.Payload.DelegationDepthRemaining)
+	assert.Nil(t, token.Payload.ParentAuthorityHash) // root envelope
+}
+
+func TestDeriveEnvelope_Basic(t *testing.T) {
+	svc := newTestSimpleGuardService(t)
+	parentKey, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+	childKey, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+
+	// Create root
+	rootResp, _ := svc.CreateEnvelope(ctx, &pb.CreateEnvelopeRequest{
+		KeyId:                    parentKey.KeyId,
+		SubjectDid:               childKey.DidKey,
+		CapabilityClass:          "tools.database",
+		DelegationDepthRemaining: 3,
+		IssuerBadgeJti:           "badge-parent",
+	})
+	require.Empty(t, rootResp.ErrorMessage)
+
+	// Derive child
+	childResp, err := svc.DeriveEnvelope(ctx, &pb.DeriveEnvelopeRequest{
+		ParentEnvelopeJws:        rootResp.EnvelopeJws,
+		KeyId:                    childKey.KeyId,
+		SubjectDid:               "did:key:z6MkLeaf",
+		CapabilityClass:          "tools.database.read", // narrower
+		DelegationDepthRemaining: 1,
+		SubjectBadgeJti:          "badge-child",
+		IssuerBadgeJti:           "badge-child-issuer",
+	})
+	require.NoError(t, err)
+	assert.Empty(t, childResp.ErrorMessage)
+	assert.NotEmpty(t, childResp.EnvelopeJws)
+	assert.NotEmpty(t, childResp.ParentAuthorityHash)
+}
+
+func TestDeriveEnvelope_NarrowingViolation(t *testing.T) {
+	svc := newTestSimpleGuardService(t)
+	parentKey, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+	childKey, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+
+	rootResp, _ := svc.CreateEnvelope(ctx, &pb.CreateEnvelopeRequest{
+		KeyId:                    parentKey.KeyId,
+		SubjectDid:               childKey.DidKey,
+		CapabilityClass:          "tools.database.read", // specific
+		DelegationDepthRemaining: 2,
+		IssuerBadgeJti:           "badge-parent",
+	})
+
+	// Try to widen capability — should fail
+	childResp, err := svc.DeriveEnvelope(ctx, &pb.DeriveEnvelopeRequest{
+		ParentEnvelopeJws:        rootResp.EnvelopeJws,
+		KeyId:                    childKey.KeyId,
+		SubjectDid:               "did:key:z6MkLeaf",
+		CapabilityClass:          "tools.database", // WIDER — violation
+		DelegationDepthRemaining: 1,
+		IssuerBadgeJti:           "badge-child-issuer",
+	})
+	require.NoError(t, err) // no Go error — app error in response
+	assert.Contains(t, childResp.ErrorMessage, "narrowing")
+}
+
+func TestDeriveEnvelope_IssuerBadgeJTI_NotInherited(t *testing.T) {
+	svc := newTestSimpleGuardService(t)
+	parentKey, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+	childKey, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+
+	rootResp, _ := svc.CreateEnvelope(ctx, &pb.CreateEnvelopeRequest{
+		KeyId:                    parentKey.KeyId,
+		SubjectDid:               childKey.DidKey,
+		CapabilityClass:          "tools.database",
+		DelegationDepthRemaining: 3,
+		IssuerBadgeJti:           "root-issuer-badge",
+	})
+	require.Empty(t, rootResp.ErrorMessage)
+
+	childResp, err := svc.DeriveEnvelope(ctx, &pb.DeriveEnvelopeRequest{
+		ParentEnvelopeJws:        rootResp.EnvelopeJws,
+		KeyId:                    childKey.KeyId,
+		SubjectDid:               "did:key:z6MkLeaf",
+		CapabilityClass:          "tools.database.read",
+		DelegationDepthRemaining: 1,
+		IssuerBadgeJti:           "child-issuer-badge",
+		SubjectBadgeJti:          "leaf-badge",
+	})
+	require.NoError(t, err)
+	require.Empty(t, childResp.ErrorMessage)
+
+	// Parse the child envelope and verify issuer badge JTI
+	childToken, err := envelope.ParseToken(childResp.EnvelopeJws)
+	require.NoError(t, err)
+	assert.Equal(t, "child-issuer-badge", childToken.Payload.IssuerBadgeJTI,
+		"child envelope must have the CHILD issuer's badge JTI, not the parent's")
+	assert.NotEqual(t, "root-issuer-badge", childToken.Payload.IssuerBadgeJTI,
+		"child envelope must NOT inherit the parent issuer's badge JTI")
+}
+
+func TestCreateEnvelope_SubjectBadgeJTI_Optional(t *testing.T) {
+	svc := newTestSimpleGuardService(t)
+	key, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+
+	// Without subject badge
+	resp1, _ := svc.CreateEnvelope(ctx, &pb.CreateEnvelopeRequest{
+		KeyId:                    key.KeyId,
+		SubjectDid:               "did:key:z6MkTest",
+		CapabilityClass:          "tools.database.read",
+		DelegationDepthRemaining: 3,
+		IssuerBadgeJti:           "badge-123",
+	})
+	require.Empty(t, resp1.ErrorMessage)
+	token1, _ := envelope.ParseToken(resp1.EnvelopeJws)
+	assert.Nil(t, token1.Payload.SubjectBadgeJTI, "SubjectBadgeJTI should be nil when not provided")
+
+	// With subject badge
+	resp2, _ := svc.CreateEnvelope(ctx, &pb.CreateEnvelopeRequest{
+		KeyId:                    key.KeyId,
+		SubjectDid:               "did:key:z6MkTest",
+		CapabilityClass:          "tools.database.read",
+		DelegationDepthRemaining: 3,
+		IssuerBadgeJti:           "badge-123",
+		SubjectBadgeJti:          "subject-badge-456",
+	})
+	require.Empty(t, resp2.ErrorMessage)
+	token2, _ := envelope.ParseToken(resp2.EnvelopeJws)
+	require.NotNil(t, token2.Payload.SubjectBadgeJTI)
+	assert.Equal(t, "subject-badge-456", *token2.Payload.SubjectBadgeJTI)
+}
+
+func TestCreateEnvelope_EnforcementModeMin_StringType(t *testing.T) {
+	svc := newTestSimpleGuardService(t)
+	key, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+
+	// Without enforcement mode
+	resp1, _ := svc.CreateEnvelope(ctx, &pb.CreateEnvelopeRequest{
+		KeyId:                    key.KeyId,
+		SubjectDid:               "did:key:z6MkTest",
+		CapabilityClass:          "tools.database",
+		DelegationDepthRemaining: 3,
+		IssuerBadgeJti:           "badge-123",
+	})
+	require.Empty(t, resp1.ErrorMessage)
+	token1, _ := envelope.ParseToken(resp1.EnvelopeJws)
+	assert.Nil(t, token1.Payload.EnforcementModeMin, "should be nil when not provided")
+
+	// With enforcement mode
+	resp2, _ := svc.CreateEnvelope(ctx, &pb.CreateEnvelopeRequest{
+		KeyId:                    key.KeyId,
+		SubjectDid:               "did:key:z6MkTest",
+		CapabilityClass:          "tools.database",
+		DelegationDepthRemaining: 3,
+		IssuerBadgeJti:           "badge-123",
+		EnforcementModeMin:       "EM-STRICT",
+	})
+	require.Empty(t, resp2.ErrorMessage)
+	token2, _ := envelope.ParseToken(resp2.EnvelopeJws)
+	require.NotNil(t, token2.Payload.EnforcementModeMin)
+	assert.Equal(t, "EM-STRICT", *token2.Payload.EnforcementModeMin)
+}
+
+func TestDeriveEnvelope_InheritsParentEnforcementMode(t *testing.T) {
+	svc := newTestSimpleGuardService(t)
+	parentKey, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+	childKey, _ := svc.GenerateKeyPair(ctx, &pb.GenerateKeyPairRequest{Algorithm: pb.KeyAlgorithm_KEY_ALGORITHM_ED25519})
+
+	rootResp, _ := svc.CreateEnvelope(ctx, &pb.CreateEnvelopeRequest{
+		KeyId:                    parentKey.KeyId,
+		SubjectDid:               childKey.DidKey,
+		CapabilityClass:          "tools.database",
+		DelegationDepthRemaining: 3,
+		IssuerBadgeJti:           "badge-parent",
+		EnforcementModeMin:       "EM-STRICT",
+	})
+	require.Empty(t, rootResp.ErrorMessage)
+
+	// Derive child WITHOUT specifying enforcement_mode_min
+	childResp, err := svc.DeriveEnvelope(ctx, &pb.DeriveEnvelopeRequest{
+		ParentEnvelopeJws:        rootResp.EnvelopeJws,
+		KeyId:                    childKey.KeyId,
+		SubjectDid:               "did:key:z6MkLeaf",
+		CapabilityClass:          "tools.database.read",
+		DelegationDepthRemaining: 1,
+		IssuerBadgeJti:           "badge-child",
+	})
+	require.NoError(t, err)
+	require.Empty(t, childResp.ErrorMessage)
+
+	childToken, err := envelope.ParseToken(childResp.EnvelopeJws)
+	require.NoError(t, err)
+	require.NotNil(t, childToken.Payload.EnforcementModeMin)
+	assert.Equal(t, "EM-STRICT", *childToken.Payload.EnforcementModeMin,
+		"child should inherit parent's enforcement_mode_min when not specified")
+}
+
+func TestBuildTransportHeaders_Encoding(t *testing.T) {
+	svc := newTestSimpleGuardService(t)
+
+	chain := []string{"eyJhbGciOiJFZERTQSJ9.root.sig", "eyJhbGciOiJFZERTQSJ9.leaf.sig"}
+	badgeMap := map[string]string{"did:key:issuer": "badge-jws-1"}
+
+	resp, err := svc.BuildTransportHeaders(ctx, &pb.BuildTransportHeadersRequest{
+		Chain:    chain,
+		BadgeMap: badgeMap,
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.ErrorMessage)
+	assert.Equal(t, chain[1], resp.AuthorityHeader) // leaf
+	assert.NotEmpty(t, resp.AuthorityChainHeader)
+	assert.NotEmpty(t, resp.BadgeMapHeader)
+
+	// Verify chain header can be decoded
+	decoded, err := base64.RawURLEncoding.DecodeString(resp.AuthorityChainHeader)
+	require.NoError(t, err)
+	var decodedChain []string
+	require.NoError(t, json.Unmarshal(decoded, &decodedChain))
+	assert.Equal(t, chain, decodedChain)
+}

--- a/pkg/rpc/gen/capiscio/v1/simpleguard.pb.go
+++ b/pkg/rpc/gen/capiscio/v1/simpleguard.pb.go
@@ -1390,6 +1390,670 @@ func (x *InitResponse) GetErrorMessage() string {
 	return ""
 }
 
+// Request to create a root Authority Envelope
+type CreateEnvelopeRequest struct {
+	state                    protoimpl.MessageState `protogen:"open.v1"`
+	KeyId                    string                 `protobuf:"bytes,1,opt,name=key_id,json=keyId,proto3" json:"key_id,omitempty"`                                                             // Key to sign with (from key store)
+	SubjectDid               string                 `protobuf:"bytes,2,opt,name=subject_did,json=subjectDid,proto3" json:"subject_did,omitempty"`                                              // DID of the agent receiving authority
+	CapabilityClass          string                 `protobuf:"bytes,3,opt,name=capability_class,json=capabilityClass,proto3" json:"capability_class,omitempty"`                               // e.g., "tools.database.read"
+	DelegationDepthRemaining int32                  `protobuf:"varint,4,opt,name=delegation_depth_remaining,json=delegationDepthRemaining,proto3" json:"delegation_depth_remaining,omitempty"` // How many further delegations allowed
+	TxnId                    string                 `protobuf:"bytes,5,opt,name=txn_id,json=txnId,proto3" json:"txn_id,omitempty"`                                                             // Transaction ID (RFC-004); auto-generated if empty
+	ExpiresInSeconds         int64                  `protobuf:"varint,6,opt,name=expires_in_seconds,json=expiresInSeconds,proto3" json:"expires_in_seconds,omitempty"`                         // TTL from now (default: 3600)
+	ConstraintsJson          string                 `protobuf:"bytes,7,opt,name=constraints_json,json=constraintsJson,proto3" json:"constraints_json,omitempty"`                               // Optional JSON constraints object
+	IssuerBadgeJti           string                 `protobuf:"bytes,8,opt,name=issuer_badge_jti,json=issuerBadgeJti,proto3" json:"issuer_badge_jti,omitempty"`                                // JTI of the issuer's badge
+	SubjectBadgeJti          string                 `protobuf:"bytes,9,opt,name=subject_badge_jti,json=subjectBadgeJti,proto3" json:"subject_badge_jti,omitempty"`                             // JTI of the subject's badge (optional)
+	EnforcementModeMin       string                 `protobuf:"bytes,10,opt,name=enforcement_mode_min,json=enforcementModeMin,proto3" json:"enforcement_mode_min,omitempty"`                   // Optional minimum enforcement mode
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *CreateEnvelopeRequest) Reset() {
+	*x = CreateEnvelopeRequest{}
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[18]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateEnvelopeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateEnvelopeRequest) ProtoMessage() {}
+
+func (x *CreateEnvelopeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[18]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateEnvelopeRequest.ProtoReflect.Descriptor instead.
+func (*CreateEnvelopeRequest) Descriptor() ([]byte, []int) {
+	return file_capiscio_v1_simpleguard_proto_rawDescGZIP(), []int{18}
+}
+
+func (x *CreateEnvelopeRequest) GetKeyId() string {
+	if x != nil {
+		return x.KeyId
+	}
+	return ""
+}
+
+func (x *CreateEnvelopeRequest) GetSubjectDid() string {
+	if x != nil {
+		return x.SubjectDid
+	}
+	return ""
+}
+
+func (x *CreateEnvelopeRequest) GetCapabilityClass() string {
+	if x != nil {
+		return x.CapabilityClass
+	}
+	return ""
+}
+
+func (x *CreateEnvelopeRequest) GetDelegationDepthRemaining() int32 {
+	if x != nil {
+		return x.DelegationDepthRemaining
+	}
+	return 0
+}
+
+func (x *CreateEnvelopeRequest) GetTxnId() string {
+	if x != nil {
+		return x.TxnId
+	}
+	return ""
+}
+
+func (x *CreateEnvelopeRequest) GetExpiresInSeconds() int64 {
+	if x != nil {
+		return x.ExpiresInSeconds
+	}
+	return 0
+}
+
+func (x *CreateEnvelopeRequest) GetConstraintsJson() string {
+	if x != nil {
+		return x.ConstraintsJson
+	}
+	return ""
+}
+
+func (x *CreateEnvelopeRequest) GetIssuerBadgeJti() string {
+	if x != nil {
+		return x.IssuerBadgeJti
+	}
+	return ""
+}
+
+func (x *CreateEnvelopeRequest) GetSubjectBadgeJti() string {
+	if x != nil {
+		return x.SubjectBadgeJti
+	}
+	return ""
+}
+
+func (x *CreateEnvelopeRequest) GetEnforcementModeMin() string {
+	if x != nil {
+		return x.EnforcementModeMin
+	}
+	return ""
+}
+
+// Response with signed root envelope
+type CreateEnvelopeResponse struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	EnvelopeJws   string                 `protobuf:"bytes,1,opt,name=envelope_jws,json=envelopeJws,proto3" json:"envelope_jws,omitempty"` // JWS Compact Serialization
+	EnvelopeId    string                 `protobuf:"bytes,2,opt,name=envelope_id,json=envelopeId,proto3" json:"envelope_id,omitempty"`    // Generated envelope UUID
+	IssuerDid     string                 `protobuf:"bytes,3,opt,name=issuer_did,json=issuerDid,proto3" json:"issuer_did,omitempty"`       // DID derived from signing key
+	ErrorMessage  string                 `protobuf:"bytes,4,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *CreateEnvelopeResponse) Reset() {
+	*x = CreateEnvelopeResponse{}
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[19]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *CreateEnvelopeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*CreateEnvelopeResponse) ProtoMessage() {}
+
+func (x *CreateEnvelopeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[19]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use CreateEnvelopeResponse.ProtoReflect.Descriptor instead.
+func (*CreateEnvelopeResponse) Descriptor() ([]byte, []int) {
+	return file_capiscio_v1_simpleguard_proto_rawDescGZIP(), []int{19}
+}
+
+func (x *CreateEnvelopeResponse) GetEnvelopeJws() string {
+	if x != nil {
+		return x.EnvelopeJws
+	}
+	return ""
+}
+
+func (x *CreateEnvelopeResponse) GetEnvelopeId() string {
+	if x != nil {
+		return x.EnvelopeId
+	}
+	return ""
+}
+
+func (x *CreateEnvelopeResponse) GetIssuerDid() string {
+	if x != nil {
+		return x.IssuerDid
+	}
+	return ""
+}
+
+func (x *CreateEnvelopeResponse) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+// Request to derive a child envelope from a parent
+type DeriveEnvelopeRequest struct {
+	state                    protoimpl.MessageState `protogen:"open.v1"`
+	ParentEnvelopeJws        string                 `protobuf:"bytes,1,opt,name=parent_envelope_jws,json=parentEnvelopeJws,proto3" json:"parent_envelope_jws,omitempty"`                       // Parent envelope JWS (will be parsed + hash-linked)
+	KeyId                    string                 `protobuf:"bytes,2,opt,name=key_id,json=keyId,proto3" json:"key_id,omitempty"`                                                             // Key to sign child with
+	SubjectDid               string                 `protobuf:"bytes,3,opt,name=subject_did,json=subjectDid,proto3" json:"subject_did,omitempty"`                                              // DID of the next delegate
+	CapabilityClass          string                 `protobuf:"bytes,4,opt,name=capability_class,json=capabilityClass,proto3" json:"capability_class,omitempty"`                               // Must be equal or narrower than parent
+	DelegationDepthRemaining int32                  `protobuf:"varint,5,opt,name=delegation_depth_remaining,json=delegationDepthRemaining,proto3" json:"delegation_depth_remaining,omitempty"` // Must be < parent's depth
+	ExpiresInSeconds         int64                  `protobuf:"varint,6,opt,name=expires_in_seconds,json=expiresInSeconds,proto3" json:"expires_in_seconds,omitempty"`                         // TTL from now (must be <= parent expiry)
+	ConstraintsJson          string                 `protobuf:"bytes,7,opt,name=constraints_json,json=constraintsJson,proto3" json:"constraints_json,omitempty"`                               // Must be equal or more restrictive
+	SubjectBadgeJti          string                 `protobuf:"bytes,8,opt,name=subject_badge_jti,json=subjectBadgeJti,proto3" json:"subject_badge_jti,omitempty"`                             // JTI of the subject's badge
+	EnforcementModeMin       string                 `protobuf:"bytes,9,opt,name=enforcement_mode_min,json=enforcementModeMin,proto3" json:"enforcement_mode_min,omitempty"`                    // Optional minimum enforcement mode
+	IssuerBadgeJti           string                 `protobuf:"bytes,10,opt,name=issuer_badge_jti,json=issuerBadgeJti,proto3" json:"issuer_badge_jti,omitempty"`                               // JTI of the child issuer's own badge (NOT inherited from parent)
+	unknownFields            protoimpl.UnknownFields
+	sizeCache                protoimpl.SizeCache
+}
+
+func (x *DeriveEnvelopeRequest) Reset() {
+	*x = DeriveEnvelopeRequest{}
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[20]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeriveEnvelopeRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeriveEnvelopeRequest) ProtoMessage() {}
+
+func (x *DeriveEnvelopeRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[20]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeriveEnvelopeRequest.ProtoReflect.Descriptor instead.
+func (*DeriveEnvelopeRequest) Descriptor() ([]byte, []int) {
+	return file_capiscio_v1_simpleguard_proto_rawDescGZIP(), []int{20}
+}
+
+func (x *DeriveEnvelopeRequest) GetParentEnvelopeJws() string {
+	if x != nil {
+		return x.ParentEnvelopeJws
+	}
+	return ""
+}
+
+func (x *DeriveEnvelopeRequest) GetKeyId() string {
+	if x != nil {
+		return x.KeyId
+	}
+	return ""
+}
+
+func (x *DeriveEnvelopeRequest) GetSubjectDid() string {
+	if x != nil {
+		return x.SubjectDid
+	}
+	return ""
+}
+
+func (x *DeriveEnvelopeRequest) GetCapabilityClass() string {
+	if x != nil {
+		return x.CapabilityClass
+	}
+	return ""
+}
+
+func (x *DeriveEnvelopeRequest) GetDelegationDepthRemaining() int32 {
+	if x != nil {
+		return x.DelegationDepthRemaining
+	}
+	return 0
+}
+
+func (x *DeriveEnvelopeRequest) GetExpiresInSeconds() int64 {
+	if x != nil {
+		return x.ExpiresInSeconds
+	}
+	return 0
+}
+
+func (x *DeriveEnvelopeRequest) GetConstraintsJson() string {
+	if x != nil {
+		return x.ConstraintsJson
+	}
+	return ""
+}
+
+func (x *DeriveEnvelopeRequest) GetSubjectBadgeJti() string {
+	if x != nil {
+		return x.SubjectBadgeJti
+	}
+	return ""
+}
+
+func (x *DeriveEnvelopeRequest) GetEnforcementModeMin() string {
+	if x != nil {
+		return x.EnforcementModeMin
+	}
+	return ""
+}
+
+func (x *DeriveEnvelopeRequest) GetIssuerBadgeJti() string {
+	if x != nil {
+		return x.IssuerBadgeJti
+	}
+	return ""
+}
+
+// Response with signed derived envelope
+type DeriveEnvelopeResponse struct {
+	state               protoimpl.MessageState `protogen:"open.v1"`
+	EnvelopeJws         string                 `protobuf:"bytes,1,opt,name=envelope_jws,json=envelopeJws,proto3" json:"envelope_jws,omitempty"`                           // JWS Compact Serialization of child
+	EnvelopeId          string                 `protobuf:"bytes,2,opt,name=envelope_id,json=envelopeId,proto3" json:"envelope_id,omitempty"`                              // Generated envelope UUID
+	ParentAuthorityHash string                 `protobuf:"bytes,3,opt,name=parent_authority_hash,json=parentAuthorityHash,proto3" json:"parent_authority_hash,omitempty"` // SHA-256 hash linking to parent
+	ErrorMessage        string                 `protobuf:"bytes,4,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	unknownFields       protoimpl.UnknownFields
+	sizeCache           protoimpl.SizeCache
+}
+
+func (x *DeriveEnvelopeResponse) Reset() {
+	*x = DeriveEnvelopeResponse{}
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[21]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *DeriveEnvelopeResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*DeriveEnvelopeResponse) ProtoMessage() {}
+
+func (x *DeriveEnvelopeResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[21]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use DeriveEnvelopeResponse.ProtoReflect.Descriptor instead.
+func (*DeriveEnvelopeResponse) Descriptor() ([]byte, []int) {
+	return file_capiscio_v1_simpleguard_proto_rawDescGZIP(), []int{21}
+}
+
+func (x *DeriveEnvelopeResponse) GetEnvelopeJws() string {
+	if x != nil {
+		return x.EnvelopeJws
+	}
+	return ""
+}
+
+func (x *DeriveEnvelopeResponse) GetEnvelopeId() string {
+	if x != nil {
+		return x.EnvelopeId
+	}
+	return ""
+}
+
+func (x *DeriveEnvelopeResponse) GetParentAuthorityHash() string {
+	if x != nil {
+		return x.ParentAuthorityHash
+	}
+	return ""
+}
+
+func (x *DeriveEnvelopeResponse) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+// Request to build transport headers for a delegation chain
+type BuildTransportHeadersRequest struct {
+	state         protoimpl.MessageState `protogen:"open.v1"`
+	Chain         []string               `protobuf:"bytes,1,rep,name=chain,proto3" json:"chain,omitempty"`                                                                                                 // Ordered JWS array [root, ..., leaf]
+	BadgeMap      map[string]string      `protobuf:"bytes,2,rep,name=badge_map,json=badgeMap,proto3" json:"badge_map,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // DID -> badge JWS for intermediate agents
+	unknownFields protoimpl.UnknownFields
+	sizeCache     protoimpl.SizeCache
+}
+
+func (x *BuildTransportHeadersRequest) Reset() {
+	*x = BuildTransportHeadersRequest{}
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[22]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BuildTransportHeadersRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BuildTransportHeadersRequest) ProtoMessage() {}
+
+func (x *BuildTransportHeadersRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[22]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BuildTransportHeadersRequest.ProtoReflect.Descriptor instead.
+func (*BuildTransportHeadersRequest) Descriptor() ([]byte, []int) {
+	return file_capiscio_v1_simpleguard_proto_rawDescGZIP(), []int{22}
+}
+
+func (x *BuildTransportHeadersRequest) GetChain() []string {
+	if x != nil {
+		return x.Chain
+	}
+	return nil
+}
+
+func (x *BuildTransportHeadersRequest) GetBadgeMap() map[string]string {
+	if x != nil {
+		return x.BadgeMap
+	}
+	return nil
+}
+
+// Response with encoded transport headers
+type BuildTransportHeadersResponse struct {
+	state                protoimpl.MessageState `protogen:"open.v1"`
+	AuthorityHeader      string                 `protobuf:"bytes,1,opt,name=authority_header,json=authorityHeader,proto3" json:"authority_header,omitempty"`                  // X-Capiscio-Authority value (leaf JWS)
+	AuthorityChainHeader string                 `protobuf:"bytes,2,opt,name=authority_chain_header,json=authorityChainHeader,proto3" json:"authority_chain_header,omitempty"` // X-Capiscio-Authority-Chain value (base64url JSON array)
+	BadgeMapHeader       string                 `protobuf:"bytes,3,opt,name=badge_map_header,json=badgeMapHeader,proto3" json:"badge_map_header,omitempty"`                   // X-Capiscio-Badge-Map value (base64url JSON object)
+	ErrorMessage         string                 `protobuf:"bytes,4,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	unknownFields        protoimpl.UnknownFields
+	sizeCache            protoimpl.SizeCache
+}
+
+func (x *BuildTransportHeadersResponse) Reset() {
+	*x = BuildTransportHeadersResponse{}
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[23]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *BuildTransportHeadersResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*BuildTransportHeadersResponse) ProtoMessage() {}
+
+func (x *BuildTransportHeadersResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[23]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use BuildTransportHeadersResponse.ProtoReflect.Descriptor instead.
+func (*BuildTransportHeadersResponse) Descriptor() ([]byte, []int) {
+	return file_capiscio_v1_simpleguard_proto_rawDescGZIP(), []int{23}
+}
+
+func (x *BuildTransportHeadersResponse) GetAuthorityHeader() string {
+	if x != nil {
+		return x.AuthorityHeader
+	}
+	return ""
+}
+
+func (x *BuildTransportHeadersResponse) GetAuthorityChainHeader() string {
+	if x != nil {
+		return x.AuthorityChainHeader
+	}
+	return ""
+}
+
+func (x *BuildTransportHeadersResponse) GetBadgeMapHeader() string {
+	if x != nil {
+		return x.BadgeMapHeader
+	}
+	return ""
+}
+
+func (x *BuildTransportHeadersResponse) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
+// Request to verify an envelope chain
+type VerifyEnvelopeChainRequest struct {
+	state           protoimpl.MessageState `protogen:"open.v1"`
+	Chain           []string               `protobuf:"bytes,1,rep,name=chain,proto3" json:"chain,omitempty"`                                                                                                 // Ordered JWS array [root, ..., leaf]
+	BadgeMap        map[string]string      `protobuf:"bytes,2,rep,name=badge_map,json=badgeMap,proto3" json:"badge_map,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"` // DID -> badge JWS
+	TrustedIssuers  []string               `protobuf:"bytes,3,rep,name=trusted_issuers,json=trustedIssuers,proto3" json:"trusted_issuers,omitempty"`                                                         // Trusted issuer DIDs (optional)
+	EnforcementMode string                 `protobuf:"bytes,4,opt,name=enforcement_mode,json=enforcementMode,proto3" json:"enforcement_mode,omitempty"`                                                      // Enforcement mode for verification
+	unknownFields   protoimpl.UnknownFields
+	sizeCache       protoimpl.SizeCache
+}
+
+func (x *VerifyEnvelopeChainRequest) Reset() {
+	*x = VerifyEnvelopeChainRequest{}
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[24]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VerifyEnvelopeChainRequest) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VerifyEnvelopeChainRequest) ProtoMessage() {}
+
+func (x *VerifyEnvelopeChainRequest) ProtoReflect() protoreflect.Message {
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[24]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VerifyEnvelopeChainRequest.ProtoReflect.Descriptor instead.
+func (*VerifyEnvelopeChainRequest) Descriptor() ([]byte, []int) {
+	return file_capiscio_v1_simpleguard_proto_rawDescGZIP(), []int{24}
+}
+
+func (x *VerifyEnvelopeChainRequest) GetChain() []string {
+	if x != nil {
+		return x.Chain
+	}
+	return nil
+}
+
+func (x *VerifyEnvelopeChainRequest) GetBadgeMap() map[string]string {
+	if x != nil {
+		return x.BadgeMap
+	}
+	return nil
+}
+
+func (x *VerifyEnvelopeChainRequest) GetTrustedIssuers() []string {
+	if x != nil {
+		return x.TrustedIssuers
+	}
+	return nil
+}
+
+func (x *VerifyEnvelopeChainRequest) GetEnforcementMode() string {
+	if x != nil {
+		return x.EnforcementMode
+	}
+	return ""
+}
+
+// Response from chain verification
+type VerifyEnvelopeChainResponse struct {
+	state          protoimpl.MessageState `protogen:"open.v1"`
+	Valid          bool                   `protobuf:"varint,1,opt,name=valid,proto3" json:"valid,omitempty"`
+	RootCapability string                 `protobuf:"bytes,2,opt,name=root_capability,json=rootCapability,proto3" json:"root_capability,omitempty"`
+	LeafCapability string                 `protobuf:"bytes,3,opt,name=leaf_capability,json=leafCapability,proto3" json:"leaf_capability,omitempty"`
+	TotalDepth     int32                  `protobuf:"varint,4,opt,name=total_depth,json=totalDepth,proto3" json:"total_depth,omitempty"`
+	LeafIssuerDid  string                 `protobuf:"bytes,5,opt,name=leaf_issuer_did,json=leafIssuerDid,proto3" json:"leaf_issuer_did,omitempty"`
+	LeafSubjectDid string                 `protobuf:"bytes,6,opt,name=leaf_subject_did,json=leafSubjectDid,proto3" json:"leaf_subject_did,omitempty"`
+	ErrorCode      string                 `protobuf:"bytes,7,opt,name=error_code,json=errorCode,proto3" json:"error_code,omitempty"` // RFC-008 section 9.3 error code (on failure)
+	ErrorMessage   string                 `protobuf:"bytes,8,opt,name=error_message,json=errorMessage,proto3" json:"error_message,omitempty"`
+	unknownFields  protoimpl.UnknownFields
+	sizeCache      protoimpl.SizeCache
+}
+
+func (x *VerifyEnvelopeChainResponse) Reset() {
+	*x = VerifyEnvelopeChainResponse{}
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[25]
+	ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+	ms.StoreMessageInfo(mi)
+}
+
+func (x *VerifyEnvelopeChainResponse) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*VerifyEnvelopeChainResponse) ProtoMessage() {}
+
+func (x *VerifyEnvelopeChainResponse) ProtoReflect() protoreflect.Message {
+	mi := &file_capiscio_v1_simpleguard_proto_msgTypes[25]
+	if x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use VerifyEnvelopeChainResponse.ProtoReflect.Descriptor instead.
+func (*VerifyEnvelopeChainResponse) Descriptor() ([]byte, []int) {
+	return file_capiscio_v1_simpleguard_proto_rawDescGZIP(), []int{25}
+}
+
+func (x *VerifyEnvelopeChainResponse) GetValid() bool {
+	if x != nil {
+		return x.Valid
+	}
+	return false
+}
+
+func (x *VerifyEnvelopeChainResponse) GetRootCapability() string {
+	if x != nil {
+		return x.RootCapability
+	}
+	return ""
+}
+
+func (x *VerifyEnvelopeChainResponse) GetLeafCapability() string {
+	if x != nil {
+		return x.LeafCapability
+	}
+	return ""
+}
+
+func (x *VerifyEnvelopeChainResponse) GetTotalDepth() int32 {
+	if x != nil {
+		return x.TotalDepth
+	}
+	return 0
+}
+
+func (x *VerifyEnvelopeChainResponse) GetLeafIssuerDid() string {
+	if x != nil {
+		return x.LeafIssuerDid
+	}
+	return ""
+}
+
+func (x *VerifyEnvelopeChainResponse) GetLeafSubjectDid() string {
+	if x != nil {
+		return x.LeafSubjectDid
+	}
+	return ""
+}
+
+func (x *VerifyEnvelopeChainResponse) GetErrorCode() string {
+	if x != nil {
+		return x.ErrorCode
+	}
+	return ""
+}
+
+func (x *VerifyEnvelopeChainResponse) GetErrorMessage() string {
+	if x != nil {
+		return x.ErrorMessage
+	}
+	return ""
+}
+
 var File_capiscio_v1_simpleguard_proto protoreflect.FileDescriptor
 
 const file_capiscio_v1_simpleguard_proto_rawDesc = "" +
@@ -1526,12 +2190,81 @@ const file_capiscio_v1_simpleguard_proto_rawDesc = "" +
 	"\n" +
 	"registered\x18\a \x01(\bR\n" +
 	"registered\x12#\n" +
+	"\rerror_message\x18\b \x01(\tR\ferrorMessage\"\xb0\x03\n" +
+	"\x15CreateEnvelopeRequest\x12\x15\n" +
+	"\x06key_id\x18\x01 \x01(\tR\x05keyId\x12\x1f\n" +
+	"\vsubject_did\x18\x02 \x01(\tR\n" +
+	"subjectDid\x12)\n" +
+	"\x10capability_class\x18\x03 \x01(\tR\x0fcapabilityClass\x12<\n" +
+	"\x1adelegation_depth_remaining\x18\x04 \x01(\x05R\x18delegationDepthRemaining\x12\x15\n" +
+	"\x06txn_id\x18\x05 \x01(\tR\x05txnId\x12,\n" +
+	"\x12expires_in_seconds\x18\x06 \x01(\x03R\x10expiresInSeconds\x12)\n" +
+	"\x10constraints_json\x18\a \x01(\tR\x0fconstraintsJson\x12(\n" +
+	"\x10issuer_badge_jti\x18\b \x01(\tR\x0eissuerBadgeJti\x12*\n" +
+	"\x11subject_badge_jti\x18\t \x01(\tR\x0fsubjectBadgeJti\x120\n" +
+	"\x14enforcement_mode_min\x18\n" +
+	" \x01(\tR\x12enforcementModeMin\"\xa0\x01\n" +
+	"\x16CreateEnvelopeResponse\x12!\n" +
+	"\fenvelope_jws\x18\x01 \x01(\tR\venvelopeJws\x12\x1f\n" +
+	"\venvelope_id\x18\x02 \x01(\tR\n" +
+	"envelopeId\x12\x1d\n" +
+	"\n" +
+	"issuer_did\x18\x03 \x01(\tR\tissuerDid\x12#\n" +
+	"\rerror_message\x18\x04 \x01(\tR\ferrorMessage\"\xc9\x03\n" +
+	"\x15DeriveEnvelopeRequest\x12.\n" +
+	"\x13parent_envelope_jws\x18\x01 \x01(\tR\x11parentEnvelopeJws\x12\x15\n" +
+	"\x06key_id\x18\x02 \x01(\tR\x05keyId\x12\x1f\n" +
+	"\vsubject_did\x18\x03 \x01(\tR\n" +
+	"subjectDid\x12)\n" +
+	"\x10capability_class\x18\x04 \x01(\tR\x0fcapabilityClass\x12<\n" +
+	"\x1adelegation_depth_remaining\x18\x05 \x01(\x05R\x18delegationDepthRemaining\x12,\n" +
+	"\x12expires_in_seconds\x18\x06 \x01(\x03R\x10expiresInSeconds\x12)\n" +
+	"\x10constraints_json\x18\a \x01(\tR\x0fconstraintsJson\x12*\n" +
+	"\x11subject_badge_jti\x18\b \x01(\tR\x0fsubjectBadgeJti\x120\n" +
+	"\x14enforcement_mode_min\x18\t \x01(\tR\x12enforcementModeMin\x12(\n" +
+	"\x10issuer_badge_jti\x18\n" +
+	" \x01(\tR\x0eissuerBadgeJti\"\xb5\x01\n" +
+	"\x16DeriveEnvelopeResponse\x12!\n" +
+	"\fenvelope_jws\x18\x01 \x01(\tR\venvelopeJws\x12\x1f\n" +
+	"\venvelope_id\x18\x02 \x01(\tR\n" +
+	"envelopeId\x122\n" +
+	"\x15parent_authority_hash\x18\x03 \x01(\tR\x13parentAuthorityHash\x12#\n" +
+	"\rerror_message\x18\x04 \x01(\tR\ferrorMessage\"\xc7\x01\n" +
+	"\x1cBuildTransportHeadersRequest\x12\x14\n" +
+	"\x05chain\x18\x01 \x03(\tR\x05chain\x12T\n" +
+	"\tbadge_map\x18\x02 \x03(\v27.capiscio.v1.BuildTransportHeadersRequest.BadgeMapEntryR\bbadgeMap\x1a;\n" +
+	"\rBadgeMapEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xcf\x01\n" +
+	"\x1dBuildTransportHeadersResponse\x12)\n" +
+	"\x10authority_header\x18\x01 \x01(\tR\x0fauthorityHeader\x124\n" +
+	"\x16authority_chain_header\x18\x02 \x01(\tR\x14authorityChainHeader\x12(\n" +
+	"\x10badge_map_header\x18\x03 \x01(\tR\x0ebadgeMapHeader\x12#\n" +
+	"\rerror_message\x18\x04 \x01(\tR\ferrorMessage\"\x97\x02\n" +
+	"\x1aVerifyEnvelopeChainRequest\x12\x14\n" +
+	"\x05chain\x18\x01 \x03(\tR\x05chain\x12R\n" +
+	"\tbadge_map\x18\x02 \x03(\v25.capiscio.v1.VerifyEnvelopeChainRequest.BadgeMapEntryR\bbadgeMap\x12'\n" +
+	"\x0ftrusted_issuers\x18\x03 \x03(\tR\x0etrustedIssuers\x12)\n" +
+	"\x10enforcement_mode\x18\x04 \x01(\tR\x0fenforcementMode\x1a;\n" +
+	"\rBadgeMapEntry\x12\x10\n" +
+	"\x03key\x18\x01 \x01(\tR\x03key\x12\x14\n" +
+	"\x05value\x18\x02 \x01(\tR\x05value:\x028\x01\"\xbc\x02\n" +
+	"\x1bVerifyEnvelopeChainResponse\x12\x14\n" +
+	"\x05valid\x18\x01 \x01(\bR\x05valid\x12'\n" +
+	"\x0froot_capability\x18\x02 \x01(\tR\x0erootCapability\x12'\n" +
+	"\x0fleaf_capability\x18\x03 \x01(\tR\x0eleafCapability\x12\x1f\n" +
+	"\vtotal_depth\x18\x04 \x01(\x05R\n" +
+	"totalDepth\x12&\n" +
+	"\x0fleaf_issuer_did\x18\x05 \x01(\tR\rleafIssuerDid\x12(\n" +
+	"\x10leaf_subject_did\x18\x06 \x01(\tR\x0eleafSubjectDid\x12\x1d\n" +
+	"\n" +
+	"error_code\x18\a \x01(\tR\terrorCode\x12#\n" +
 	"\rerror_message\x18\b \x01(\tR\ferrorMessage*\x8e\x01\n" +
 	"\x0fSignatureFormat\x12 \n" +
 	"\x1cSIGNATURE_FORMAT_UNSPECIFIED\x10\x00\x12 \n" +
 	"\x1cSIGNATURE_FORMAT_JWS_COMPACT\x10\x01\x12\x1d\n" +
 	"\x19SIGNATURE_FORMAT_JWS_JSON\x10\x02\x12\x18\n" +
-	"\x14SIGNATURE_FORMAT_RAW\x10\x032\xc0\x05\n" +
+	"\x14SIGNATURE_FORMAT_RAW\x10\x032\xd0\b\n" +
 	"\x12SimpleGuardService\x12;\n" +
 	"\x04Sign\x12\x18.capiscio.v1.SignRequest\x1a\x19.capiscio.v1.SignResponse\x12A\n" +
 	"\x06Verify\x12\x1a.capiscio.v1.VerifyRequest\x1a\x1b.capiscio.v1.VerifyResponse\x12S\n" +
@@ -1542,7 +2275,11 @@ const file_capiscio_v1_simpleguard_proto_rawDesc = "" +
 	"\tExportKey\x12\x1d.capiscio.v1.ExportKeyRequest\x1a\x1e.capiscio.v1.ExportKeyResponse\x12M\n" +
 	"\n" +
 	"GetKeyInfo\x12\x1e.capiscio.v1.GetKeyInfoRequest\x1a\x1f.capiscio.v1.GetKeyInfoResponse\x12;\n" +
-	"\x04Init\x12\x18.capiscio.v1.InitRequest\x1a\x19.capiscio.v1.InitResponseB\xb6\x01\n" +
+	"\x04Init\x12\x18.capiscio.v1.InitRequest\x1a\x19.capiscio.v1.InitResponse\x12Y\n" +
+	"\x0eCreateEnvelope\x12\".capiscio.v1.CreateEnvelopeRequest\x1a#.capiscio.v1.CreateEnvelopeResponse\x12Y\n" +
+	"\x0eDeriveEnvelope\x12\".capiscio.v1.DeriveEnvelopeRequest\x1a#.capiscio.v1.DeriveEnvelopeResponse\x12n\n" +
+	"\x15BuildTransportHeaders\x12).capiscio.v1.BuildTransportHeadersRequest\x1a*.capiscio.v1.BuildTransportHeadersResponse\x12h\n" +
+	"\x13VerifyEnvelopeChain\x12'.capiscio.v1.VerifyEnvelopeChainRequest\x1a(.capiscio.v1.VerifyEnvelopeChainResponseB\xb6\x01\n" +
 	"\x0fcom.capiscio.v1B\x10SimpleguardProtoP\x01ZDgithub.com/capiscio/capiscio-core/pkg/rpc/gen/capiscio/v1;capisciov1\xa2\x02\x03CXX\xaa\x02\vCapiscio.V1\xca\x02\vCapiscio\\V1\xe2\x02\x17Capiscio\\V1\\GPBMetadata\xea\x02\fCapiscio::V1b\x06proto3"
 
 var (
@@ -1558,78 +2295,98 @@ func file_capiscio_v1_simpleguard_proto_rawDescGZIP() []byte {
 }
 
 var file_capiscio_v1_simpleguard_proto_enumTypes = make([]protoimpl.EnumInfo, 1)
-var file_capiscio_v1_simpleguard_proto_msgTypes = make([]protoimpl.MessageInfo, 23)
+var file_capiscio_v1_simpleguard_proto_msgTypes = make([]protoimpl.MessageInfo, 33)
 var file_capiscio_v1_simpleguard_proto_goTypes = []any{
-	(SignatureFormat)(0),            // 0: capiscio.v1.SignatureFormat
-	(*SignRequest)(nil),             // 1: capiscio.v1.SignRequest
-	(*SignResponse)(nil),            // 2: capiscio.v1.SignResponse
-	(*VerifyRequest)(nil),           // 3: capiscio.v1.VerifyRequest
-	(*VerifyResponse)(nil),          // 4: capiscio.v1.VerifyResponse
-	(*SignAttachedRequest)(nil),     // 5: capiscio.v1.SignAttachedRequest
-	(*SignAttachedResponse)(nil),    // 6: capiscio.v1.SignAttachedResponse
-	(*VerifyAttachedRequest)(nil),   // 7: capiscio.v1.VerifyAttachedRequest
-	(*VerifyAttachedResponse)(nil),  // 8: capiscio.v1.VerifyAttachedResponse
-	(*GenerateKeyPairRequest)(nil),  // 9: capiscio.v1.GenerateKeyPairRequest
-	(*GenerateKeyPairResponse)(nil), // 10: capiscio.v1.GenerateKeyPairResponse
-	(*LoadKeyRequest)(nil),          // 11: capiscio.v1.LoadKeyRequest
-	(*LoadKeyResponse)(nil),         // 12: capiscio.v1.LoadKeyResponse
-	(*ExportKeyRequest)(nil),        // 13: capiscio.v1.ExportKeyRequest
-	(*ExportKeyResponse)(nil),       // 14: capiscio.v1.ExportKeyResponse
-	(*GetKeyInfoRequest)(nil),       // 15: capiscio.v1.GetKeyInfoRequest
-	(*GetKeyInfoResponse)(nil),      // 16: capiscio.v1.GetKeyInfoResponse
-	(*InitRequest)(nil),             // 17: capiscio.v1.InitRequest
-	(*InitResponse)(nil),            // 18: capiscio.v1.InitResponse
-	nil,                             // 19: capiscio.v1.SignRequest.HeadersEntry
-	nil,                             // 20: capiscio.v1.SignAttachedRequest.HeadersEntry
-	nil,                             // 21: capiscio.v1.GenerateKeyPairRequest.MetadataEntry
-	nil,                             // 22: capiscio.v1.GetKeyInfoResponse.MetadataEntry
-	nil,                             // 23: capiscio.v1.InitRequest.MetadataEntry
-	(*ValidationResult)(nil),        // 24: capiscio.v1.ValidationResult
-	(KeyAlgorithm)(0),               // 25: capiscio.v1.KeyAlgorithm
-	(KeyFormat)(0),                  // 26: capiscio.v1.KeyFormat
-	(*Timestamp)(nil),               // 27: capiscio.v1.Timestamp
+	(SignatureFormat)(0),                  // 0: capiscio.v1.SignatureFormat
+	(*SignRequest)(nil),                   // 1: capiscio.v1.SignRequest
+	(*SignResponse)(nil),                  // 2: capiscio.v1.SignResponse
+	(*VerifyRequest)(nil),                 // 3: capiscio.v1.VerifyRequest
+	(*VerifyResponse)(nil),                // 4: capiscio.v1.VerifyResponse
+	(*SignAttachedRequest)(nil),           // 5: capiscio.v1.SignAttachedRequest
+	(*SignAttachedResponse)(nil),          // 6: capiscio.v1.SignAttachedResponse
+	(*VerifyAttachedRequest)(nil),         // 7: capiscio.v1.VerifyAttachedRequest
+	(*VerifyAttachedResponse)(nil),        // 8: capiscio.v1.VerifyAttachedResponse
+	(*GenerateKeyPairRequest)(nil),        // 9: capiscio.v1.GenerateKeyPairRequest
+	(*GenerateKeyPairResponse)(nil),       // 10: capiscio.v1.GenerateKeyPairResponse
+	(*LoadKeyRequest)(nil),                // 11: capiscio.v1.LoadKeyRequest
+	(*LoadKeyResponse)(nil),               // 12: capiscio.v1.LoadKeyResponse
+	(*ExportKeyRequest)(nil),              // 13: capiscio.v1.ExportKeyRequest
+	(*ExportKeyResponse)(nil),             // 14: capiscio.v1.ExportKeyResponse
+	(*GetKeyInfoRequest)(nil),             // 15: capiscio.v1.GetKeyInfoRequest
+	(*GetKeyInfoResponse)(nil),            // 16: capiscio.v1.GetKeyInfoResponse
+	(*InitRequest)(nil),                   // 17: capiscio.v1.InitRequest
+	(*InitResponse)(nil),                  // 18: capiscio.v1.InitResponse
+	(*CreateEnvelopeRequest)(nil),         // 19: capiscio.v1.CreateEnvelopeRequest
+	(*CreateEnvelopeResponse)(nil),        // 20: capiscio.v1.CreateEnvelopeResponse
+	(*DeriveEnvelopeRequest)(nil),         // 21: capiscio.v1.DeriveEnvelopeRequest
+	(*DeriveEnvelopeResponse)(nil),        // 22: capiscio.v1.DeriveEnvelopeResponse
+	(*BuildTransportHeadersRequest)(nil),  // 23: capiscio.v1.BuildTransportHeadersRequest
+	(*BuildTransportHeadersResponse)(nil), // 24: capiscio.v1.BuildTransportHeadersResponse
+	(*VerifyEnvelopeChainRequest)(nil),    // 25: capiscio.v1.VerifyEnvelopeChainRequest
+	(*VerifyEnvelopeChainResponse)(nil),   // 26: capiscio.v1.VerifyEnvelopeChainResponse
+	nil,                                   // 27: capiscio.v1.SignRequest.HeadersEntry
+	nil,                                   // 28: capiscio.v1.SignAttachedRequest.HeadersEntry
+	nil,                                   // 29: capiscio.v1.GenerateKeyPairRequest.MetadataEntry
+	nil,                                   // 30: capiscio.v1.GetKeyInfoResponse.MetadataEntry
+	nil,                                   // 31: capiscio.v1.InitRequest.MetadataEntry
+	nil,                                   // 32: capiscio.v1.BuildTransportHeadersRequest.BadgeMapEntry
+	nil,                                   // 33: capiscio.v1.VerifyEnvelopeChainRequest.BadgeMapEntry
+	(*ValidationResult)(nil),              // 34: capiscio.v1.ValidationResult
+	(KeyAlgorithm)(0),                     // 35: capiscio.v1.KeyAlgorithm
+	(KeyFormat)(0),                        // 36: capiscio.v1.KeyFormat
+	(*Timestamp)(nil),                     // 37: capiscio.v1.Timestamp
 }
 var file_capiscio_v1_simpleguard_proto_depIdxs = []int32{
 	0,  // 0: capiscio.v1.SignRequest.format:type_name -> capiscio.v1.SignatureFormat
-	19, // 1: capiscio.v1.SignRequest.headers:type_name -> capiscio.v1.SignRequest.HeadersEntry
-	24, // 2: capiscio.v1.VerifyResponse.validation:type_name -> capiscio.v1.ValidationResult
+	27, // 1: capiscio.v1.SignRequest.headers:type_name -> capiscio.v1.SignRequest.HeadersEntry
+	34, // 2: capiscio.v1.VerifyResponse.validation:type_name -> capiscio.v1.ValidationResult
 	0,  // 3: capiscio.v1.SignAttachedRequest.format:type_name -> capiscio.v1.SignatureFormat
-	20, // 4: capiscio.v1.SignAttachedRequest.headers:type_name -> capiscio.v1.SignAttachedRequest.HeadersEntry
-	24, // 5: capiscio.v1.VerifyAttachedResponse.validation:type_name -> capiscio.v1.ValidationResult
-	25, // 6: capiscio.v1.GenerateKeyPairRequest.algorithm:type_name -> capiscio.v1.KeyAlgorithm
-	21, // 7: capiscio.v1.GenerateKeyPairRequest.metadata:type_name -> capiscio.v1.GenerateKeyPairRequest.MetadataEntry
-	25, // 8: capiscio.v1.GenerateKeyPairResponse.algorithm:type_name -> capiscio.v1.KeyAlgorithm
-	26, // 9: capiscio.v1.LoadKeyRequest.format:type_name -> capiscio.v1.KeyFormat
-	25, // 10: capiscio.v1.LoadKeyResponse.algorithm:type_name -> capiscio.v1.KeyAlgorithm
-	26, // 11: capiscio.v1.ExportKeyRequest.format:type_name -> capiscio.v1.KeyFormat
-	25, // 12: capiscio.v1.GetKeyInfoResponse.algorithm:type_name -> capiscio.v1.KeyAlgorithm
-	27, // 13: capiscio.v1.GetKeyInfoResponse.created_at:type_name -> capiscio.v1.Timestamp
-	22, // 14: capiscio.v1.GetKeyInfoResponse.metadata:type_name -> capiscio.v1.GetKeyInfoResponse.MetadataEntry
-	25, // 15: capiscio.v1.InitRequest.algorithm:type_name -> capiscio.v1.KeyAlgorithm
-	23, // 16: capiscio.v1.InitRequest.metadata:type_name -> capiscio.v1.InitRequest.MetadataEntry
-	1,  // 17: capiscio.v1.SimpleGuardService.Sign:input_type -> capiscio.v1.SignRequest
-	3,  // 18: capiscio.v1.SimpleGuardService.Verify:input_type -> capiscio.v1.VerifyRequest
-	5,  // 19: capiscio.v1.SimpleGuardService.SignAttached:input_type -> capiscio.v1.SignAttachedRequest
-	7,  // 20: capiscio.v1.SimpleGuardService.VerifyAttached:input_type -> capiscio.v1.VerifyAttachedRequest
-	9,  // 21: capiscio.v1.SimpleGuardService.GenerateKeyPair:input_type -> capiscio.v1.GenerateKeyPairRequest
-	11, // 22: capiscio.v1.SimpleGuardService.LoadKey:input_type -> capiscio.v1.LoadKeyRequest
-	13, // 23: capiscio.v1.SimpleGuardService.ExportKey:input_type -> capiscio.v1.ExportKeyRequest
-	15, // 24: capiscio.v1.SimpleGuardService.GetKeyInfo:input_type -> capiscio.v1.GetKeyInfoRequest
-	17, // 25: capiscio.v1.SimpleGuardService.Init:input_type -> capiscio.v1.InitRequest
-	2,  // 26: capiscio.v1.SimpleGuardService.Sign:output_type -> capiscio.v1.SignResponse
-	4,  // 27: capiscio.v1.SimpleGuardService.Verify:output_type -> capiscio.v1.VerifyResponse
-	6,  // 28: capiscio.v1.SimpleGuardService.SignAttached:output_type -> capiscio.v1.SignAttachedResponse
-	8,  // 29: capiscio.v1.SimpleGuardService.VerifyAttached:output_type -> capiscio.v1.VerifyAttachedResponse
-	10, // 30: capiscio.v1.SimpleGuardService.GenerateKeyPair:output_type -> capiscio.v1.GenerateKeyPairResponse
-	12, // 31: capiscio.v1.SimpleGuardService.LoadKey:output_type -> capiscio.v1.LoadKeyResponse
-	14, // 32: capiscio.v1.SimpleGuardService.ExportKey:output_type -> capiscio.v1.ExportKeyResponse
-	16, // 33: capiscio.v1.SimpleGuardService.GetKeyInfo:output_type -> capiscio.v1.GetKeyInfoResponse
-	18, // 34: capiscio.v1.SimpleGuardService.Init:output_type -> capiscio.v1.InitResponse
-	26, // [26:35] is the sub-list for method output_type
-	17, // [17:26] is the sub-list for method input_type
-	17, // [17:17] is the sub-list for extension type_name
-	17, // [17:17] is the sub-list for extension extendee
-	0,  // [0:17] is the sub-list for field type_name
+	28, // 4: capiscio.v1.SignAttachedRequest.headers:type_name -> capiscio.v1.SignAttachedRequest.HeadersEntry
+	34, // 5: capiscio.v1.VerifyAttachedResponse.validation:type_name -> capiscio.v1.ValidationResult
+	35, // 6: capiscio.v1.GenerateKeyPairRequest.algorithm:type_name -> capiscio.v1.KeyAlgorithm
+	29, // 7: capiscio.v1.GenerateKeyPairRequest.metadata:type_name -> capiscio.v1.GenerateKeyPairRequest.MetadataEntry
+	35, // 8: capiscio.v1.GenerateKeyPairResponse.algorithm:type_name -> capiscio.v1.KeyAlgorithm
+	36, // 9: capiscio.v1.LoadKeyRequest.format:type_name -> capiscio.v1.KeyFormat
+	35, // 10: capiscio.v1.LoadKeyResponse.algorithm:type_name -> capiscio.v1.KeyAlgorithm
+	36, // 11: capiscio.v1.ExportKeyRequest.format:type_name -> capiscio.v1.KeyFormat
+	35, // 12: capiscio.v1.GetKeyInfoResponse.algorithm:type_name -> capiscio.v1.KeyAlgorithm
+	37, // 13: capiscio.v1.GetKeyInfoResponse.created_at:type_name -> capiscio.v1.Timestamp
+	30, // 14: capiscio.v1.GetKeyInfoResponse.metadata:type_name -> capiscio.v1.GetKeyInfoResponse.MetadataEntry
+	35, // 15: capiscio.v1.InitRequest.algorithm:type_name -> capiscio.v1.KeyAlgorithm
+	31, // 16: capiscio.v1.InitRequest.metadata:type_name -> capiscio.v1.InitRequest.MetadataEntry
+	32, // 17: capiscio.v1.BuildTransportHeadersRequest.badge_map:type_name -> capiscio.v1.BuildTransportHeadersRequest.BadgeMapEntry
+	33, // 18: capiscio.v1.VerifyEnvelopeChainRequest.badge_map:type_name -> capiscio.v1.VerifyEnvelopeChainRequest.BadgeMapEntry
+	1,  // 19: capiscio.v1.SimpleGuardService.Sign:input_type -> capiscio.v1.SignRequest
+	3,  // 20: capiscio.v1.SimpleGuardService.Verify:input_type -> capiscio.v1.VerifyRequest
+	5,  // 21: capiscio.v1.SimpleGuardService.SignAttached:input_type -> capiscio.v1.SignAttachedRequest
+	7,  // 22: capiscio.v1.SimpleGuardService.VerifyAttached:input_type -> capiscio.v1.VerifyAttachedRequest
+	9,  // 23: capiscio.v1.SimpleGuardService.GenerateKeyPair:input_type -> capiscio.v1.GenerateKeyPairRequest
+	11, // 24: capiscio.v1.SimpleGuardService.LoadKey:input_type -> capiscio.v1.LoadKeyRequest
+	13, // 25: capiscio.v1.SimpleGuardService.ExportKey:input_type -> capiscio.v1.ExportKeyRequest
+	15, // 26: capiscio.v1.SimpleGuardService.GetKeyInfo:input_type -> capiscio.v1.GetKeyInfoRequest
+	17, // 27: capiscio.v1.SimpleGuardService.Init:input_type -> capiscio.v1.InitRequest
+	19, // 28: capiscio.v1.SimpleGuardService.CreateEnvelope:input_type -> capiscio.v1.CreateEnvelopeRequest
+	21, // 29: capiscio.v1.SimpleGuardService.DeriveEnvelope:input_type -> capiscio.v1.DeriveEnvelopeRequest
+	23, // 30: capiscio.v1.SimpleGuardService.BuildTransportHeaders:input_type -> capiscio.v1.BuildTransportHeadersRequest
+	25, // 31: capiscio.v1.SimpleGuardService.VerifyEnvelopeChain:input_type -> capiscio.v1.VerifyEnvelopeChainRequest
+	2,  // 32: capiscio.v1.SimpleGuardService.Sign:output_type -> capiscio.v1.SignResponse
+	4,  // 33: capiscio.v1.SimpleGuardService.Verify:output_type -> capiscio.v1.VerifyResponse
+	6,  // 34: capiscio.v1.SimpleGuardService.SignAttached:output_type -> capiscio.v1.SignAttachedResponse
+	8,  // 35: capiscio.v1.SimpleGuardService.VerifyAttached:output_type -> capiscio.v1.VerifyAttachedResponse
+	10, // 36: capiscio.v1.SimpleGuardService.GenerateKeyPair:output_type -> capiscio.v1.GenerateKeyPairResponse
+	12, // 37: capiscio.v1.SimpleGuardService.LoadKey:output_type -> capiscio.v1.LoadKeyResponse
+	14, // 38: capiscio.v1.SimpleGuardService.ExportKey:output_type -> capiscio.v1.ExportKeyResponse
+	16, // 39: capiscio.v1.SimpleGuardService.GetKeyInfo:output_type -> capiscio.v1.GetKeyInfoResponse
+	18, // 40: capiscio.v1.SimpleGuardService.Init:output_type -> capiscio.v1.InitResponse
+	20, // 41: capiscio.v1.SimpleGuardService.CreateEnvelope:output_type -> capiscio.v1.CreateEnvelopeResponse
+	22, // 42: capiscio.v1.SimpleGuardService.DeriveEnvelope:output_type -> capiscio.v1.DeriveEnvelopeResponse
+	24, // 43: capiscio.v1.SimpleGuardService.BuildTransportHeaders:output_type -> capiscio.v1.BuildTransportHeadersResponse
+	26, // 44: capiscio.v1.SimpleGuardService.VerifyEnvelopeChain:output_type -> capiscio.v1.VerifyEnvelopeChainResponse
+	32, // [32:45] is the sub-list for method output_type
+	19, // [19:32] is the sub-list for method input_type
+	19, // [19:19] is the sub-list for extension type_name
+	19, // [19:19] is the sub-list for extension extendee
+	0,  // [0:19] is the sub-list for field type_name
 }
 
 func init() { file_capiscio_v1_simpleguard_proto_init() }
@@ -1645,7 +2402,7 @@ func file_capiscio_v1_simpleguard_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: unsafe.Slice(unsafe.StringData(file_capiscio_v1_simpleguard_proto_rawDesc), len(file_capiscio_v1_simpleguard_proto_rawDesc)),
 			NumEnums:      1,
-			NumMessages:   23,
+			NumMessages:   33,
 			NumExtensions: 0,
 			NumServices:   1,
 		},

--- a/pkg/rpc/gen/capiscio/v1/simpleguard_grpc.pb.go
+++ b/pkg/rpc/gen/capiscio/v1/simpleguard_grpc.pb.go
@@ -21,15 +21,19 @@ import (
 const _ = grpc.SupportPackageIsVersion9
 
 const (
-	SimpleGuardService_Sign_FullMethodName            = "/capiscio.v1.SimpleGuardService/Sign"
-	SimpleGuardService_Verify_FullMethodName          = "/capiscio.v1.SimpleGuardService/Verify"
-	SimpleGuardService_SignAttached_FullMethodName    = "/capiscio.v1.SimpleGuardService/SignAttached"
-	SimpleGuardService_VerifyAttached_FullMethodName  = "/capiscio.v1.SimpleGuardService/VerifyAttached"
-	SimpleGuardService_GenerateKeyPair_FullMethodName = "/capiscio.v1.SimpleGuardService/GenerateKeyPair"
-	SimpleGuardService_LoadKey_FullMethodName         = "/capiscio.v1.SimpleGuardService/LoadKey"
-	SimpleGuardService_ExportKey_FullMethodName       = "/capiscio.v1.SimpleGuardService/ExportKey"
-	SimpleGuardService_GetKeyInfo_FullMethodName      = "/capiscio.v1.SimpleGuardService/GetKeyInfo"
-	SimpleGuardService_Init_FullMethodName            = "/capiscio.v1.SimpleGuardService/Init"
+	SimpleGuardService_Sign_FullMethodName                  = "/capiscio.v1.SimpleGuardService/Sign"
+	SimpleGuardService_Verify_FullMethodName                = "/capiscio.v1.SimpleGuardService/Verify"
+	SimpleGuardService_SignAttached_FullMethodName          = "/capiscio.v1.SimpleGuardService/SignAttached"
+	SimpleGuardService_VerifyAttached_FullMethodName        = "/capiscio.v1.SimpleGuardService/VerifyAttached"
+	SimpleGuardService_GenerateKeyPair_FullMethodName       = "/capiscio.v1.SimpleGuardService/GenerateKeyPair"
+	SimpleGuardService_LoadKey_FullMethodName               = "/capiscio.v1.SimpleGuardService/LoadKey"
+	SimpleGuardService_ExportKey_FullMethodName             = "/capiscio.v1.SimpleGuardService/ExportKey"
+	SimpleGuardService_GetKeyInfo_FullMethodName            = "/capiscio.v1.SimpleGuardService/GetKeyInfo"
+	SimpleGuardService_Init_FullMethodName                  = "/capiscio.v1.SimpleGuardService/Init"
+	SimpleGuardService_CreateEnvelope_FullMethodName        = "/capiscio.v1.SimpleGuardService/CreateEnvelope"
+	SimpleGuardService_DeriveEnvelope_FullMethodName        = "/capiscio.v1.SimpleGuardService/DeriveEnvelope"
+	SimpleGuardService_BuildTransportHeaders_FullMethodName = "/capiscio.v1.SimpleGuardService/BuildTransportHeaders"
+	SimpleGuardService_VerifyEnvelopeChain_FullMethodName   = "/capiscio.v1.SimpleGuardService/VerifyEnvelopeChain"
 )
 
 // SimpleGuardServiceClient is the client API for SimpleGuardService service.
@@ -57,6 +61,14 @@ type SimpleGuardServiceClient interface {
 	// Initialize agent identity (Let's Encrypt style one-call setup)
 	// Generates key pair, derives DID, registers with server, creates agent card
 	Init(ctx context.Context, in *InitRequest, opts ...grpc.CallOption) (*InitResponse, error)
+	// RFC-008: Create a root Authority Envelope (§6.1)
+	CreateEnvelope(ctx context.Context, in *CreateEnvelopeRequest, opts ...grpc.CallOption) (*CreateEnvelopeResponse, error)
+	// RFC-008: Derive a child Authority Envelope from a parent (§6.3)
+	DeriveEnvelope(ctx context.Context, in *DeriveEnvelopeRequest, opts ...grpc.CallOption) (*DeriveEnvelopeResponse, error)
+	// RFC-008: Build transport headers for a delegation chain (§15.1–§15.3)
+	BuildTransportHeaders(ctx context.Context, in *BuildTransportHeadersRequest, opts ...grpc.CallOption) (*BuildTransportHeadersResponse, error)
+	// RFC-008: Verify an Authority Envelope chain (§9.2)
+	VerifyEnvelopeChain(ctx context.Context, in *VerifyEnvelopeChainRequest, opts ...grpc.CallOption) (*VerifyEnvelopeChainResponse, error)
 }
 
 type simpleGuardServiceClient struct {
@@ -157,6 +169,46 @@ func (c *simpleGuardServiceClient) Init(ctx context.Context, in *InitRequest, op
 	return out, nil
 }
 
+func (c *simpleGuardServiceClient) CreateEnvelope(ctx context.Context, in *CreateEnvelopeRequest, opts ...grpc.CallOption) (*CreateEnvelopeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(CreateEnvelopeResponse)
+	err := c.cc.Invoke(ctx, SimpleGuardService_CreateEnvelope_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *simpleGuardServiceClient) DeriveEnvelope(ctx context.Context, in *DeriveEnvelopeRequest, opts ...grpc.CallOption) (*DeriveEnvelopeResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(DeriveEnvelopeResponse)
+	err := c.cc.Invoke(ctx, SimpleGuardService_DeriveEnvelope_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *simpleGuardServiceClient) BuildTransportHeaders(ctx context.Context, in *BuildTransportHeadersRequest, opts ...grpc.CallOption) (*BuildTransportHeadersResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(BuildTransportHeadersResponse)
+	err := c.cc.Invoke(ctx, SimpleGuardService_BuildTransportHeaders_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+func (c *simpleGuardServiceClient) VerifyEnvelopeChain(ctx context.Context, in *VerifyEnvelopeChainRequest, opts ...grpc.CallOption) (*VerifyEnvelopeChainResponse, error) {
+	cOpts := append([]grpc.CallOption{grpc.StaticMethod()}, opts...)
+	out := new(VerifyEnvelopeChainResponse)
+	err := c.cc.Invoke(ctx, SimpleGuardService_VerifyEnvelopeChain_FullMethodName, in, out, cOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
 // SimpleGuardServiceServer is the server API for SimpleGuardService service.
 // All implementations must embed UnimplementedSimpleGuardServiceServer
 // for forward compatibility.
@@ -182,6 +234,14 @@ type SimpleGuardServiceServer interface {
 	// Initialize agent identity (Let's Encrypt style one-call setup)
 	// Generates key pair, derives DID, registers with server, creates agent card
 	Init(context.Context, *InitRequest) (*InitResponse, error)
+	// RFC-008: Create a root Authority Envelope (§6.1)
+	CreateEnvelope(context.Context, *CreateEnvelopeRequest) (*CreateEnvelopeResponse, error)
+	// RFC-008: Derive a child Authority Envelope from a parent (§6.3)
+	DeriveEnvelope(context.Context, *DeriveEnvelopeRequest) (*DeriveEnvelopeResponse, error)
+	// RFC-008: Build transport headers for a delegation chain (§15.1–§15.3)
+	BuildTransportHeaders(context.Context, *BuildTransportHeadersRequest) (*BuildTransportHeadersResponse, error)
+	// RFC-008: Verify an Authority Envelope chain (§9.2)
+	VerifyEnvelopeChain(context.Context, *VerifyEnvelopeChainRequest) (*VerifyEnvelopeChainResponse, error)
 	mustEmbedUnimplementedSimpleGuardServiceServer()
 }
 
@@ -218,6 +278,18 @@ func (UnimplementedSimpleGuardServiceServer) GetKeyInfo(context.Context, *GetKey
 }
 func (UnimplementedSimpleGuardServiceServer) Init(context.Context, *InitRequest) (*InitResponse, error) {
 	return nil, status.Error(codes.Unimplemented, "method Init not implemented")
+}
+func (UnimplementedSimpleGuardServiceServer) CreateEnvelope(context.Context, *CreateEnvelopeRequest) (*CreateEnvelopeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method CreateEnvelope not implemented")
+}
+func (UnimplementedSimpleGuardServiceServer) DeriveEnvelope(context.Context, *DeriveEnvelopeRequest) (*DeriveEnvelopeResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method DeriveEnvelope not implemented")
+}
+func (UnimplementedSimpleGuardServiceServer) BuildTransportHeaders(context.Context, *BuildTransportHeadersRequest) (*BuildTransportHeadersResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method BuildTransportHeaders not implemented")
+}
+func (UnimplementedSimpleGuardServiceServer) VerifyEnvelopeChain(context.Context, *VerifyEnvelopeChainRequest) (*VerifyEnvelopeChainResponse, error) {
+	return nil, status.Error(codes.Unimplemented, "method VerifyEnvelopeChain not implemented")
 }
 func (UnimplementedSimpleGuardServiceServer) mustEmbedUnimplementedSimpleGuardServiceServer() {}
 func (UnimplementedSimpleGuardServiceServer) testEmbeddedByValue()                            {}
@@ -402,6 +474,78 @@ func _SimpleGuardService_Init_Handler(srv interface{}, ctx context.Context, dec 
 	return interceptor(ctx, in, info, handler)
 }
 
+func _SimpleGuardService_CreateEnvelope_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(CreateEnvelopeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SimpleGuardServiceServer).CreateEnvelope(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SimpleGuardService_CreateEnvelope_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SimpleGuardServiceServer).CreateEnvelope(ctx, req.(*CreateEnvelopeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SimpleGuardService_DeriveEnvelope_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(DeriveEnvelopeRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SimpleGuardServiceServer).DeriveEnvelope(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SimpleGuardService_DeriveEnvelope_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SimpleGuardServiceServer).DeriveEnvelope(ctx, req.(*DeriveEnvelopeRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SimpleGuardService_BuildTransportHeaders_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(BuildTransportHeadersRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SimpleGuardServiceServer).BuildTransportHeaders(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SimpleGuardService_BuildTransportHeaders_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SimpleGuardServiceServer).BuildTransportHeaders(ctx, req.(*BuildTransportHeadersRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
+func _SimpleGuardService_VerifyEnvelopeChain_Handler(srv interface{}, ctx context.Context, dec func(interface{}) error, interceptor grpc.UnaryServerInterceptor) (interface{}, error) {
+	in := new(VerifyEnvelopeChainRequest)
+	if err := dec(in); err != nil {
+		return nil, err
+	}
+	if interceptor == nil {
+		return srv.(SimpleGuardServiceServer).VerifyEnvelopeChain(ctx, in)
+	}
+	info := &grpc.UnaryServerInfo{
+		Server:     srv,
+		FullMethod: SimpleGuardService_VerifyEnvelopeChain_FullMethodName,
+	}
+	handler := func(ctx context.Context, req interface{}) (interface{}, error) {
+		return srv.(SimpleGuardServiceServer).VerifyEnvelopeChain(ctx, req.(*VerifyEnvelopeChainRequest))
+	}
+	return interceptor(ctx, in, info, handler)
+}
+
 // SimpleGuardService_ServiceDesc is the grpc.ServiceDesc for SimpleGuardService service.
 // It's only intended for direct use with grpc.RegisterService,
 // and not to be introspected or modified (even as a copy)
@@ -444,6 +588,22 @@ var SimpleGuardService_ServiceDesc = grpc.ServiceDesc{
 		{
 			MethodName: "Init",
 			Handler:    _SimpleGuardService_Init_Handler,
+		},
+		{
+			MethodName: "CreateEnvelope",
+			Handler:    _SimpleGuardService_CreateEnvelope_Handler,
+		},
+		{
+			MethodName: "DeriveEnvelope",
+			Handler:    _SimpleGuardService_DeriveEnvelope_Handler,
+		},
+		{
+			MethodName: "BuildTransportHeaders",
+			Handler:    _SimpleGuardService_BuildTransportHeaders_Handler,
+		},
+		{
+			MethodName: "VerifyEnvelopeChain",
+			Handler:    _SimpleGuardService_VerifyEnvelopeChain_Handler,
 		},
 	},
 	Streams:  []grpc.StreamDesc{},

--- a/proto/capiscio/v1/simpleguard.proto
+++ b/proto/capiscio/v1/simpleguard.proto
@@ -37,6 +37,18 @@ service SimpleGuardService {
   // Initialize agent identity (Let's Encrypt style one-call setup)
   // Generates key pair, derives DID, registers with server, creates agent card
   rpc Init(InitRequest) returns (InitResponse);
+
+  // RFC-008: Create a root Authority Envelope (§6.1)
+  rpc CreateEnvelope(CreateEnvelopeRequest) returns (CreateEnvelopeResponse);
+
+  // RFC-008: Derive a child Authority Envelope from a parent (§6.3)
+  rpc DeriveEnvelope(DeriveEnvelopeRequest) returns (DeriveEnvelopeResponse);
+
+  // RFC-008: Build transport headers for a delegation chain (§15.1–§15.3)
+  rpc BuildTransportHeaders(BuildTransportHeadersRequest) returns (BuildTransportHeadersResponse);
+
+  // RFC-008: Verify an Authority Envelope chain (§9.2)
+  rpc VerifyEnvelopeChain(VerifyEnvelopeChainRequest) returns (VerifyEnvelopeChainResponse);
 }
 
 // Signature format
@@ -198,4 +210,86 @@ message InitResponse {
   string agent_card_json = 6;     // Agent card contents as JSON string
   bool registered = 7;            // Whether DID was registered with server
   string error_message = 8;       // Error if any
+}
+
+// ============================================================================
+// RFC-008: Authority Envelope Operations
+// ============================================================================
+
+// Request to create a root Authority Envelope
+message CreateEnvelopeRequest {
+  string key_id = 1;                    // Key to sign with (from key store)
+  string subject_did = 2;               // DID of the agent receiving authority
+  string capability_class = 3;          // e.g., "tools.database.read"
+  int32 delegation_depth_remaining = 4; // How many further delegations allowed
+  string txn_id = 5;                    // Transaction ID (RFC-004); auto-generated if empty
+  int64 expires_in_seconds = 6;         // TTL from now (default: 3600)
+  string constraints_json = 7;          // Optional JSON constraints object
+  string issuer_badge_jti = 8;          // JTI of the issuer's badge
+  string subject_badge_jti = 9;         // JTI of the subject's badge (optional)
+  string enforcement_mode_min = 10;     // Optional minimum enforcement mode
+}
+
+// Response with signed root envelope
+message CreateEnvelopeResponse {
+  string envelope_jws = 1;              // JWS Compact Serialization
+  string envelope_id = 2;               // Generated envelope UUID
+  string issuer_did = 3;                // DID derived from signing key
+  string error_message = 4;
+}
+
+// Request to derive a child envelope from a parent
+message DeriveEnvelopeRequest {
+  string parent_envelope_jws = 1;       // Parent envelope JWS (will be parsed + hash-linked)
+  string key_id = 2;                    // Key to sign child with
+  string subject_did = 3;               // DID of the next delegate
+  string capability_class = 4;          // Must be equal or narrower than parent
+  int32 delegation_depth_remaining = 5; // Must be < parent's depth
+  int64 expires_in_seconds = 6;         // TTL from now (must be <= parent expiry)
+  string constraints_json = 7;          // Must be equal or more restrictive
+  string subject_badge_jti = 8;         // JTI of the subject's badge
+  string enforcement_mode_min = 9;      // Optional minimum enforcement mode
+  string issuer_badge_jti = 10;         // JTI of the child issuer's own badge (NOT inherited from parent)
+}
+
+// Response with signed derived envelope
+message DeriveEnvelopeResponse {
+  string envelope_jws = 1;              // JWS Compact Serialization of child
+  string envelope_id = 2;               // Generated envelope UUID
+  string parent_authority_hash = 3;     // SHA-256 hash linking to parent
+  string error_message = 4;
+}
+
+// Request to build transport headers for a delegation chain
+message BuildTransportHeadersRequest {
+  repeated string chain = 1;            // Ordered JWS array [root, ..., leaf]
+  map<string, string> badge_map = 2;    // DID -> badge JWS for intermediate agents
+}
+
+// Response with encoded transport headers
+message BuildTransportHeadersResponse {
+  string authority_header = 1;          // X-Capiscio-Authority value (leaf JWS)
+  string authority_chain_header = 2;    // X-Capiscio-Authority-Chain value (base64url JSON array)
+  string badge_map_header = 3;          // X-Capiscio-Badge-Map value (base64url JSON object)
+  string error_message = 4;
+}
+
+// Request to verify an envelope chain
+message VerifyEnvelopeChainRequest {
+  repeated string chain = 1;            // Ordered JWS array [root, ..., leaf]
+  map<string, string> badge_map = 2;    // DID -> badge JWS
+  repeated string trusted_issuers = 3;  // Trusted issuer DIDs (optional)
+  string enforcement_mode = 4;          // Enforcement mode for verification
+}
+
+// Response from chain verification
+message VerifyEnvelopeChainResponse {
+  bool valid = 1;
+  string root_capability = 2;
+  string leaf_capability = 3;
+  int32 total_depth = 4;
+  string leaf_issuer_did = 5;
+  string leaf_subject_did = 6;
+  string error_code = 7;                // RFC-008 section 9.3 error code (on failure)
+  string error_message = 8;
 }


### PR DESCRIPTION
## Summary

Adds 4 new RPCs to `SimpleGuardService` for Authority Envelope operations (RFC-008). These enable SDKs to create, derive, transport, and verify delegation chains via gRPC without implementing crypto locally.

## Architecture

Following the established pattern: **Go core library → protobuf → gRPC → SDK wrappers**. All crypto stays in Go; SDKs wrap gRPC calls.

The envelope RPCs live on `SimpleGuardService` (not a new service) because envelope signing requires the agent's private key, which SimpleGuard already manages in its in-memory key store.

## New RPCs

| RPC | Purpose | RFC-008 Section |
|-----|---------|----------------|
| `CreateEnvelope` | Create root Authority Envelope | §6.1 |
| `DeriveEnvelope` | Derive child with hash-linking, narrowing, depth check | §6.3 |
| `BuildTransportHeaders` | Encode chain into HTTP headers | §15.1–§15.3 |
| `VerifyEnvelopeChain` | Verify chain integrity | §9.2 |

## Key Design Decisions

- **Constraints default to `{}`** — the envelope library requires a non-nil constraints map. When `constraints_json` is empty, the handler sets an empty map.
- **`IssuerBadgeJTI` in DeriveEnvelope** is the child issuer's OWN badge JTI, NOT inherited from the parent. This is a deliberate design choice per RFC-008 §6.3.
- **`EnforcementModeMin` inheritance** — when a child doesn't specify enforcement mode, it inherits the parent's minimum. Escalation is allowed, relaxation is not.
- **`SubjectBadgeJTI`** is `*string` on the Payload struct — we use `ptrIfNotEmpty()` to correctly set nil when not provided.

## Tests (8 functions)

1. `TestCreateEnvelope_Basic` — roundtrip create + parse verification
2. `TestDeriveEnvelope_Basic` — two-hop chain creation
3. `TestDeriveEnvelope_NarrowingViolation` — capability widening rejected
4. `TestDeriveEnvelope_IssuerBadgeJTI_NotInherited` — regression test for correct badge binding
5. `TestCreateEnvelope_SubjectBadgeJTI_Optional` — nil vs non-nil *string handling
6. `TestCreateEnvelope_EnforcementModeMin_StringType` — correct *string storage
7. `TestDeriveEnvelope_InheritsParentEnforcementMode` — inheritance behavior
8. `TestBuildTransportHeaders_Encoding` — base64url roundtrip

## Related

- RFC-008 v1.1 (PR capiscio/capiscio-rfcs#16)
- Independent of PR D (chain verification wiring) — can be merged in parallel
- Followed by: Python SDK wrappers in capiscio-sdk-python