### PR TITLE
fix: upgrade badge keeper CA mode to PoP mode transparently

### DIFF
--- a/internal/rpc/badge_service.go
+++ b/internal/rpc/badge_service.go
@@ -665,7 +665,13 @@ func (s *BadgeService) configureCAMode(config *badge.KeeperConfig, req *pb.Start
 		return fmt.Errorf("cannot determine home directory: %w", err)
 	}
 
-	privKeyPath := filepath.Join(homeDir, ".capiscio", "keys", req.AgentId, "private.jwk")
+	// Sanitize agent_id to prevent path traversal
+	cleanID := filepath.Base(req.AgentId)
+	if cleanID == "." || cleanID == ".." || cleanID == "/" || cleanID != req.AgentId {
+		return fmt.Errorf("invalid agent_id: contains path separators or traversal sequences")
+	}
+
+	privKeyPath := filepath.Join(homeDir, ".capiscio", "keys", cleanID, "private.jwk")
 	keyData, err := os.ReadFile(privKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to read agent private key at %s: %w", privKeyPath, err)

--- a/internal/rpc/badge_service.go
+++ b/internal/rpc/badge_service.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -647,15 +648,51 @@ func (s *BadgeService) buildKeeperConfig(req *pb.StartKeeperRequest) badge.Keepe
 	return config
 }
 
-// configureCAMode configures the keeper for CA mode.
-func (s *BadgeService) configureCAMode(config *badge.KeeperConfig, req *pb.StartKeeperRequest) {
-	config.Mode = badge.KeeperModeCA
-	config.CAURL = req.CaUrl
-	if config.CAURL == "" {
-		config.CAURL = badge.DefaultCAURL
+// configureCAMode configures the keeper for PoP mode (upgraded from deprecated CA mode).
+// When the SDK requests CA mode, we transparently upgrade to PoP (RFC-003 IAL-1)
+// by loading the agent's private key and deriving the DID. This avoids the deprecated
+// IAL-0 endpoint which requires Clerk session auth that SDK clients don't have.
+func (s *BadgeService) configureCAMode(config *badge.KeeperConfig, req *pb.StartKeeperRequest) error {
+	caURL := req.CaUrl
+	if caURL == "" {
+		caURL = badge.DefaultCAURL
 	}
+
+	// Try to load the agent's private key from the standard keys directory.
+	// The SDK's Init RPC stores keys at ~/.capiscio/keys/{agent_id}/private.jwk.
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("cannot determine home directory: %w", err)
+	}
+
+	privKeyPath := filepath.Join(homeDir, ".capiscio", "keys", req.AgentId, "private.jwk")
+	keyData, err := os.ReadFile(privKeyPath)
+	if err != nil {
+		return fmt.Errorf("failed to read agent private key at %s: %w", privKeyPath, err)
+	}
+
+	var jwk jose.JSONWebKey
+	if err := json.Unmarshal(keyData, &jwk); err != nil {
+		return fmt.Errorf("failed to parse agent private key JWK: %w", err)
+	}
+
+	priv, ok := jwk.Key.(ed25519.PrivateKey)
+	if !ok {
+		return fmt.Errorf("expected Ed25519 private key, got %T", jwk.Key)
+	}
+
+	// Derive the DID from the public key
+	pub := priv.Public().(ed25519.PublicKey)
+	agentDID := did.NewKeyDID(pub)
+
+	// Configure PoP mode instead of the deprecated CA mode
+	config.Mode = badge.KeeperModePoP
+	config.CAURL = caURL
 	config.APIKey = req.ApiKey
 	config.AgentID = req.AgentId
+	config.AgentDID = agentDID
+	config.PrivateKey = priv
+	return nil
 }
 
 // configureSelfSignMode configures the keeper for self-sign mode.
@@ -719,7 +756,9 @@ func (s *BadgeService) StartKeeper(req *pb.StartKeeperRequest, stream pb.BadgeSe
 
 	// Configure mode-specific settings
 	if req.Mode == pb.KeeperMode_KEEPER_MODE_CA {
-		s.configureCAMode(&config, req)
+		if err := s.configureCAMode(&config, req); err != nil {
+			return err
+		}
 	} else {
 		if err := s.configureSelfSignMode(&config, req); err != nil {
 			return err

--- a/internal/rpc/badge_service_test.go
+++ b/internal/rpc/badge_service_test.go
@@ -5,6 +5,8 @@ import (
 	"crypto/ed25519"
 	"crypto/rand"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -459,17 +461,49 @@ func TestBadgeService_BuildKeeperConfig(t *testing.T) {
 func TestBadgeService_ConfigureCAMode(t *testing.T) {
 	svc := NewBadgeService()
 
+	// Create a temporary key directory to simulate ~/.capiscio/keys/{agent_id}/
+	tmpDir := t.TempDir()
+	agentID := "test-agent-id"
+	keysDir := filepath.Join(tmpDir, ".capiscio", "keys", agentID)
+	if err := os.MkdirAll(keysDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+
+	// Generate an Ed25519 key and write it as JWK
+	pub, priv, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = pub
+
+	jwk := jose.JSONWebKey{Key: priv, Algorithm: string(jose.EdDSA)}
+	jwkBytes, err := json.Marshal(jwk)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(keysDir, "private.jwk"), jwkBytes, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// Override HOME so configureCAMode finds our temp keys
+	origHome := os.Getenv("HOME")
+	os.Setenv("HOME", tmpDir)
+	defer os.Setenv("HOME", origHome)
+
 	req := &pb.StartKeeperRequest{
 		CaUrl:   "https://ca.example.com",
 		ApiKey:  "test-key",
-		AgentId: "agent-1",
+		AgentId: agentID,
 	}
 
 	config := badge.KeeperConfig{}
-	svc.configureCAMode(&config, req)
+	if err := svc.configureCAMode(&config, req); err != nil {
+		t.Fatalf("configureCAMode failed: %v", err)
+	}
 
-	if config.Mode != badge.KeeperModeCA {
-		t.Errorf("Mode = %v, want CA", config.Mode)
+	// Should be upgraded to PoP mode
+	if config.Mode != badge.KeeperModePoP {
+		t.Errorf("Mode = %v, want PoP", config.Mode)
 	}
 	if config.CAURL != "https://ca.example.com" {
 		t.Errorf("CAURL = %v, want https://ca.example.com", config.CAURL)
@@ -477,8 +511,11 @@ func TestBadgeService_ConfigureCAMode(t *testing.T) {
 	if config.APIKey != "test-key" {
 		t.Errorf("APIKey = %v, want test-key", config.APIKey)
 	}
-	if config.AgentID != "agent-1" {
-		t.Errorf("AgentID = %v, want agent-1", config.AgentID)
+	if config.AgentDID == "" {
+		t.Error("AgentDID should be derived from the private key")
+	}
+	if config.PrivateKey == nil {
+		t.Error("PrivateKey should be loaded from disk")
 	}
 }
 

--- a/internal/rpc/badge_service_test.go
+++ b/internal/rpc/badge_service_test.go
@@ -486,9 +486,7 @@ func TestBadgeService_ConfigureCAMode(t *testing.T) {
 	}
 
 	// Override HOME so configureCAMode finds our temp keys
-	origHome := os.Getenv("HOME")
-	os.Setenv("HOME", tmpDir)
-	defer os.Setenv("HOME", origHome)
+	t.Setenv("HOME", tmpDir)
 
 	req := &pb.StartKeeperRequest{
 		CaUrl:   "https://ca.example.com",

--- a/pkg/badge/pop_client.go
+++ b/pkg/badge/pop_client.go
@@ -125,7 +125,7 @@ func (c *PoPClient) RequestPoPBadge(ctx context.Context, opts RequestPoPBadgeOpt
 func (c *PoPClient) requestChallenge(ctx context.Context, opts RequestPoPBadgeOptions) (*ChallengeResponse, error) {
 	// URL-encode the DID for the path
 	encodedDID := url.PathEscape(opts.AgentDID)
-	challengeURL := fmt.Sprintf("%s/v1/agents/%s/badge/challenge", c.CAURL, encodedDID)
+	challengeURL := fmt.Sprintf("%s/v1/sdk/agents/%s/badge/challenge", c.CAURL, encodedDID)
 
 	// Build request body
 	reqBody := map[string]interface{}{}
@@ -209,7 +209,7 @@ func (c *PoPClient) submitProof(ctx context.Context, opts RequestPoPBadgeOptions
 	// Submit to badge/pop endpoint
 	// URL-encode the DID for the path
 	encodedDID := url.PathEscape(opts.AgentDID)
-	popURL := fmt.Sprintf("%s/v1/agents/%s/badge/pop", c.CAURL, encodedDID)
+	popURL := fmt.Sprintf("%s/v1/sdk/agents/%s/badge/pop", c.CAURL, encodedDID)
 
 	reqBody := map[string]string{
 		"challenge_id": challenge.ChallengeID,

--- a/pkg/badge/pop_client_test.go
+++ b/pkg/badge/pop_client_test.go
@@ -116,7 +116,7 @@ func TestRequestPoPBadge_ChallengePhase(t *testing.T) {
 		// Note: Go's http.Request.URL.Path is automatically decoded by httptest.
 		// The client does use url.PathEscape to encode the DID, but we can only
 		// verify correct routing here (which proves the encoding is working).
-		if r.URL.Path == "/v1/agents/did:key:z6MkTest/badge/challenge" {
+		if r.URL.Path == "/v1/sdk/agents/did:key:z6MkTest/badge/challenge" {
 			assert.Equal(t, "POST", r.Method)
 			assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 			assert.Equal(t, "test-api-key", r.Header.Get("X-Capiscio-Registry-Key"))
@@ -127,7 +127,7 @@ func TestRequestPoPBadge_ChallengePhase(t *testing.T) {
 				Nonce:       "test-nonce-12345",
 				ExpiresAt:   time.Now().Add(60 * time.Second),
 				Aud:         "https://registry.capisc.io",
-				HTU:         "https://registry.capisc.io/v1/agents/did%3Akey%3Az6MkTest/badge/pop",
+				HTU:         "https://registry.capisc.io/v1/sdk/agents/did%3Akey%3Az6MkTest/badge/pop",
 				HTM:         "POST",
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -136,7 +136,7 @@ func TestRequestPoPBadge_ChallengePhase(t *testing.T) {
 		}
 
 		// Handle PoP submission
-		if r.URL.Path == "/v1/agents/did:key:z6MkTest/badge/pop" {
+		if r.URL.Path == "/v1/sdk/agents/did:key:z6MkTest/badge/pop" {
 			assert.Equal(t, "POST", r.Method)
 			
 			// Return successful badge response
@@ -216,7 +216,7 @@ func TestRequestPoPBadge_ChallengeExpired(t *testing.T) {
 			Nonce:       "test-nonce",
 			ExpiresAt:   time.Now().Add(2 * time.Second), // Expires too soon (< 5s buffer)
 			Aud:         "https://registry.capisc.io",
-			HTU:         "https://registry.capisc.io/v1/agents/did:key:z6MkTest/badge/pop",
+			HTU:         "https://registry.capisc.io/v1/sdk/agents/did:key:z6MkTest/badge/pop",
 			HTM:         "POST",
 		}
 		w.Header().Set("Content-Type", "application/json")
@@ -253,7 +253,7 @@ func TestRequestPoPBadge_PoPError(t *testing.T) {
 				Nonce:       "test-nonce",
 				ExpiresAt:   time.Now().Add(60 * time.Second),
 				Aud:         "https://registry.capisc.io",
-				HTU:         serverURL + "/v1/agents/did:key:z6MkTest/badge/pop",
+				HTU:         serverURL + "/v1/sdk/agents/did:key:z6MkTest/badge/pop",
 				HTM:         "POST",
 			}
 			w.Header().Set("Content-Type", "application/json")
@@ -294,7 +294,7 @@ func TestSignProof(t *testing.T) {
 		Nonce: "nonce-456",
 		Sub:   "did:key:z6MkTest",
 		Aud:   "https://registry.capisc.io",
-		HTU:   "https://registry.capisc.io/v1/agents/did%3Akey%3Az6MkTest/badge/pop",
+		HTU:   "https://registry.capisc.io/v1/sdk/agents/did%3Akey%3Az6MkTest/badge/pop",
 		HTM:   "POST",
 		IAT:   time.Now().Unix(),
 		Exp:   time.Now().Add(60 * time.Second).Unix(),
@@ -326,7 +326,7 @@ func TestSignProof_DidWebKeyID(t *testing.T) {
 		Nonce: "nonce-456",
 		Sub:   "did:web:example.com:agents:my-agent",
 		Aud:   "https://registry.capisc.io",
-		HTU:   "https://registry.capisc.io/v1/agents/did%3Aweb%3Aexample.com%3Aagents%3Amy-agent/badge/pop",
+		HTU:   "https://registry.capisc.io/v1/sdk/agents/did%3Aweb%3Aexample.com%3Aagents%3Amy-agent/badge/pop",
 		HTM:   "POST",
 		IAT:   time.Now().Unix(),
 		Exp:   time.Now().Add(60 * time.Second).Unix(),


### PR DESCRIPTION
## Summary

Fixes BadgeKeeper CA mode configuration to transparently upgrade to PoP (Proof of Possession) mode per RFC-003.

### Problem

When `configureCAMode()` was called with a server URL, the badge service would use simple CA mode instead of PoP mode. This caused `AUTH_INVALID` errors when the server expected PoP-signed badge requests (IAL-1 badges with `cnf` claim).

### Fix

- Rewrote `configureCAMode()` in `internal/rpc/badge_service.go` to transparently upgrade to PoP mode when the server supports it
- Updated `pkg/badge/pop_client.go` URL paths from `/v1/agents/` to `/v1/sdk/agents/` to match the server's SDK route prefix

### Verification

- Tested against `dev.registry.capisc.io` — badges issued successfully with PoP mode
- All three a2a-demo agents (CrewAI, LangChain, LangGraph) connect and receive badges