### PR TITLE
fix: add -tags opa_no_wasm to all build paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,16 +23,16 @@ jobs:
           go-version: '1.24.0'
 
       - name: Build Linux
-        run: GOOS=linux GOARCH=amd64 go build -o capiscio-linux-amd64 ./cmd/capiscio
+        run: GOOS=linux GOARCH=amd64 go build -tags opa_no_wasm -ldflags="-w -s" -o capiscio-linux-amd64 ./cmd/capiscio
 
       - name: Build macOS
-        run: GOOS=darwin GOARCH=amd64 go build -o capiscio-darwin-amd64 ./cmd/capiscio
+        run: GOOS=darwin GOARCH=amd64 go build -tags opa_no_wasm -ldflags="-w -s" -o capiscio-darwin-amd64 ./cmd/capiscio
 
       - name: Build macOS (ARM64)
-        run: GOOS=darwin GOARCH=arm64 go build -o capiscio-darwin-arm64 ./cmd/capiscio
+        run: GOOS=darwin GOARCH=arm64 go build -tags opa_no_wasm -ldflags="-w -s" -o capiscio-darwin-arm64 ./cmd/capiscio
 
       - name: Build Windows
-        run: GOOS=windows GOARCH=amd64 go build -o capiscio-windows-amd64.exe ./cmd/capiscio
+        run: GOOS=windows GOARCH=amd64 go build -tags opa_no_wasm -ldflags="-w -s" -o capiscio-windows-amd64.exe ./cmd/capiscio
 
       - name: Generate checksums
         run: sha256sum capiscio-linux-amd64 capiscio-darwin-amd64 capiscio-darwin-arm64 capiscio-windows-amd64.exe > checksums.txt

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,7 @@ COPY . .
 
 # Build static binary with version info
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build \
+    -tags opa_no_wasm \
     -ldflags="-w -s -X main.version=${VERSION} -X main.commit=${COMMIT}" \
     -o /capiscio \
     ./cmd/capiscio

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ docs:
 build-cli:
 	@echo "Building CLI..."
 	@mkdir -p bin
-	go build -ldflags="-w -s -X main.version=$(VERSION) -X main.commit=$(COMMIT)" \
+	go build -tags opa_no_wasm -ldflags="-w -s -X main.version=$(VERSION) -X main.commit=$(COMMIT)" \
 		-o bin/capiscio ./cmd/capiscio
 
 build-python:


### PR DESCRIPTION
## Problem

The release workflow, Dockerfile, and Makefile were building the CLI binary **without** the `opa_no_wasm` build tag. Without this tag, `pdp_init_noop.go` is compiled in — a stub that always returns `nil` for the PDP client. This means:

- **All released binaries** run in badge-only mode
- `CAPISCIO_BUNDLE_URL` is silently ignored
- OPA policy evaluation never happens
- `CAPISCIO_ENFORCEMENT_MODE` has no effect

CI was already correct (`ci.yml` has `-tags opa_no_wasm` for both build and test), so tests passed with OPA but release binaries shipped without it.

## Fix

Added `-tags opa_no_wasm` to:
- `release.yml` — all 4 platform builds (Linux, macOS x86/ARM, Windows)
- `Dockerfile` — container build
- `Makefile` — local `make build-cli`

## Impact

Every capiscio-core binary released to date has been running without OPA policy support. After this fix, the next release will include the OPA evaluator and local policy enforcement will work.