### PR TITLE
feat: did:web DID derivation, JWK registration, guard verification optimization

### DIFF
--- a/internal/rpc/badge_service.go
+++ b/internal/rpc/badge_service.go
@@ -5,6 +5,7 @@ import (
 	"crypto/ed25519"
 	"encoding/json"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -687,9 +688,14 @@ func (s *BadgeService) configureCAMode(config *badge.KeeperConfig, req *pb.Start
 		return fmt.Errorf("expected Ed25519 private key, got %T", jwk.Key)
 	}
 
-	// Derive the DID from the public key
+	// Derive the agent DID: prefer did:web when server URL and agent ID are available
 	pub := priv.Public().(ed25519.PublicKey)
-	agentDID := did.NewKeyDID(pub)
+	agentDID := did.NewKeyDID(pub) // fallback
+	if caURL != "" && req.AgentId != "" {
+		if parsed, parseErr := url.Parse(caURL); parseErr == nil && parsed.Host != "" {
+			agentDID = did.NewAgentDID(parsed.Host, req.AgentId)
+		}
+	}
 
 	// Configure PoP mode instead of the deprecated CA mode
 	config.Mode = badge.KeeperModePoP

--- a/internal/rpc/simpleguard_service.go
+++ b/internal/rpc/simpleguard_service.go
@@ -645,7 +645,7 @@ func (s *SimpleGuardService) Init(_ context.Context, req *pb.InitRequest) (*pb.I
 func (s *SimpleGuardService) registerDIDWithServer(serverURL, apiKey, agentID, agentDID string, pubJWK jose.JSONWebKey) error {
 	// Normalize URL to prevent double-slash issues
 	normalizedURL := strings.TrimRight(serverURL, "/")
-	url := fmt.Sprintf("%s/v1/sdk/agents/%s/identity", normalizedURL, agentID)
+	endpoint := fmt.Sprintf("%s/v1/sdk/agents/%s/identity", normalizedURL, url.PathEscape(agentID))
 
 	// Serialize public JWK to string (server expects JSON string, not object)
 	pubJWKBytes, err := json.Marshal(pubJWK)
@@ -663,7 +663,7 @@ func (s *SimpleGuardService) registerDIDWithServer(serverURL, apiKey, agentID, a
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPatch, url, bytes.NewReader(body))
+	req, err := http.NewRequest(http.MethodPatch, endpoint, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("failed to create request: %w", err)
 	}

--- a/internal/rpc/simpleguard_service.go
+++ b/internal/rpc/simpleguard_service.go
@@ -13,6 +13,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -599,18 +600,27 @@ func (s *SimpleGuardService) Init(_ context.Context, req *pb.InitRequest) (*pb.I
 		return &pb.InitResponse{ErrorMessage: err.Error()}, nil
 	}
 
+	// Derive agent DID: did:web when server URL and agent ID are available,
+	// otherwise fall back to did:key (offline / dev mode).
+	agentDID := keys.didKey // default: did:key
+	if req.AgentId != "" && serverURL != "" {
+		if parsed, err := url.Parse(serverURL); err == nil && parsed.Host != "" {
+			agentDID = did.NewAgentDID(parsed.Host, req.AgentId)
+		}
+	}
+
 	registered := false
 	if req.ApiKey != "" && req.AgentId != "" {
-		if err := s.registerDIDWithServer(serverURL, req.ApiKey, req.AgentId, keys.didKey); err != nil {
+		if err := s.registerDIDWithServer(serverURL, req.ApiKey, req.AgentId, agentDID, keys.pubJWK); err != nil {
 			return &pb.InitResponse{
-				Did: keys.didKey, PrivateKeyPath: keys.privKeyPath, PublicKeyPath: keys.pubKeyPath,
+				Did: agentDID, PrivateKeyPath: keys.privKeyPath, PublicKeyPath: keys.pubKeyPath,
 				ErrorMessage: fmt.Sprintf("key generated but registration failed: %v", err),
 			}, nil
 		}
 		registered = true
 	}
 
-	agentCard := initBuildAgentCard(keys.didKey, req.AgentId, keys.pubJWK, req.Metadata)
+	agentCard := initBuildAgentCard(agentDID, req.AgentId, keys.pubJWK, req.Metadata)
 	agentCardBytes, err := json.MarshalIndent(agentCard, "", "  ")
 	if err != nil {
 		return &pb.InitResponse{ErrorMessage: fmt.Sprintf("failed to marshal agent card: %v", err)}, nil
@@ -623,22 +633,29 @@ func (s *SimpleGuardService) Init(_ context.Context, req *pb.InitRequest) (*pb.I
 	}
 
 	return &pb.InitResponse{
-		Did: keys.didKey, AgentId: req.AgentId,
+		Did: agentDID, AgentId: req.AgentId,
 		PrivateKeyPath: keys.privKeyPath, PublicKeyPath: keys.pubKeyPath,
 		AgentCardPath: agentCardPath, AgentCardJson: string(agentCardBytes),
 		Registered: registered,
 	}, nil
 }
 
-// registerDIDWithServer registers DID with the CapiscIO server.
-// Uses PATCH /v1/sdk/agents/{id}/identity to update only the agent's DID (RFC-003).
-func (s *SimpleGuardService) registerDIDWithServer(serverURL, apiKey, agentID, didKey string) error {
+// registerDIDWithServer registers DID and public key with the CapiscIO server.
+// Uses PATCH /v1/sdk/agents/{id}/identity to update the agent's DID and public key (RFC-003).
+func (s *SimpleGuardService) registerDIDWithServer(serverURL, apiKey, agentID, agentDID string, pubJWK jose.JSONWebKey) error {
 	// Normalize URL to prevent double-slash issues
 	normalizedURL := strings.TrimRight(serverURL, "/")
 	url := fmt.Sprintf("%s/v1/sdk/agents/%s/identity", normalizedURL, agentID)
 
+	// Serialize public JWK to string (server expects JSON string, not object)
+	pubJWKBytes, err := json.Marshal(pubJWK)
+	if err != nil {
+		return fmt.Errorf("failed to marshal public JWK: %w", err)
+	}
+
 	payload := map[string]interface{}{
-		"did": didKey,
+		"did":       agentDID,
+		"publicKey": string(pubJWKBytes),
 	}
 
 	body, err := json.Marshal(payload)

--- a/internal/rpc/simpleguard_service_test.go
+++ b/internal/rpc/simpleguard_service_test.go
@@ -2,12 +2,16 @@ package rpc
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/go-jose/go-jose/v4"
 
 	pb "github.com/capiscio/capiscio-core/v2/pkg/rpc/gen/capiscio/v1"
 )
@@ -736,6 +740,13 @@ func TestInitBuildAgentCard(t *testing.T) {
 func TestRegisterDIDWithServer(t *testing.T) {
 	svc := NewSimpleGuardService()
 
+	// Create a valid test Ed25519 JWK for all subtests
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate test key: %v", err)
+	}
+	testJWK := jose.JSONWebKey{Key: pub, KeyID: "did:key:z6MkTest", Algorithm: string(jose.EdDSA)}
+
 	t.Run("successful registration", func(t *testing.T) {
 		type capturedRequest struct {
 			Method string
@@ -760,7 +771,7 @@ func TestRegisterDIDWithServer(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err := svc.registerDIDWithServer(server.URL, "test-api-key", "agent-123", "did:key:z6MkTest")
+		err := svc.registerDIDWithServer(server.URL, "test-api-key", "agent-123", "did:key:z6MkTest", testJWK)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -790,7 +801,7 @@ func TestRegisterDIDWithServer(t *testing.T) {
 		defer server.Close()
 
 		// Add trailing slash to server URL
-		err := svc.registerDIDWithServer(server.URL+"/", "key", "agent-id", "did:key:test")
+		err := svc.registerDIDWithServer(server.URL+"/", "key", "agent-id", "did:key:test", testJWK)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -809,7 +820,7 @@ func TestRegisterDIDWithServer(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err := svc.registerDIDWithServer(server.URL, "key", "agent-id", "did:key:test")
+		err := svc.registerDIDWithServer(server.URL, "key", "agent-id", "did:key:test", testJWK)
 		if err == nil {
 			t.Error("expected error for server error response")
 		}
@@ -821,7 +832,7 @@ func TestRegisterDIDWithServer(t *testing.T) {
 		}))
 		defer server.Close()
 
-		err := svc.registerDIDWithServer(server.URL, "bad-key", "agent-id", "did:key:test")
+		err := svc.registerDIDWithServer(server.URL, "bad-key", "agent-id", "did:key:test", testJWK)
 		if err == nil {
 			t.Error("expected error for unauthorized response")
 		}

--- a/pkg/mcp/guard.go
+++ b/pkg/mcp/guard.go
@@ -367,8 +367,10 @@ func (g *Guard) verifyBadgeCredential(
 	}
 
 	// Build verification options.
-	// Badge verification is LOCAL-ONLY: parse JWS, verify Ed25519 signature
-	// against cached CA public key, check exp. No network calls.
+	// Badge verification: parse JWS, verify Ed25519 signature against the
+	// Verifier's registry (typically a cached CA public key), check exp.
+	// Self-signed badges resolve keys locally; registry-issued badges
+	// resolve via the Verifier's registry implementation.
 	//
 	// Revocation and agent status checks are skipped because badges are
 	// short-lived (5-min TTL) and BadgeKeeper manages freshness. This is
@@ -382,7 +384,7 @@ func (g *Guard) verifyBadgeCredential(
 		SkipAgentStatusCheck: true,
 	}
 
-	// Verify badge (local crypto only — no network calls)
+	// Verify badge
 	result, err := g.badgeVerifier.VerifyWithOptions(ctx, badgeJWS, opts)
 	if err != nil {
 		// Map verification errors to deny reasons

--- a/pkg/mcp/guard.go
+++ b/pkg/mcp/guard.go
@@ -366,13 +366,23 @@ func (g *Guard) verifyBadgeCredential(
 		return "", "", 0, fmt.Errorf("%w: badge verification not available", ErrBadgeInvalid)
 	}
 
-	// Build verification options
+	// Build verification options.
+	// Badge verification is LOCAL-ONLY: parse JWS, verify Ed25519 signature
+	// against cached CA public key, check exp. No network calls.
+	//
+	// Revocation and agent status checks are skipped because badges are
+	// short-lived (5-min TTL) and BadgeKeeper manages freshness. This is
+	// the designed revocation model — a revoked badge expires within its
+	// TTL window. Online checks would add ~60-90ms of network latency
+	// per tool call, defeating the sub-millisecond design goal.
 	opts := badge.VerifyOptions{
-		TrustedIssuers:   config.TrustedIssuers,
-		AcceptSelfSigned: config.AcceptLevelZero,
+		TrustedIssuers:       config.TrustedIssuers,
+		AcceptSelfSigned:     config.AcceptLevelZero,
+		SkipRevocationCheck:  true,
+		SkipAgentStatusCheck: true,
 	}
 
-	// Verify badge
+	// Verify badge (local crypto only — no network calls)
 	result, err := g.badgeVerifier.VerifyWithOptions(ctx, badgeJWS, opts)
 	if err != nil {
 		// Map verification errors to deny reasons


### PR DESCRIPTION
## Summary

Core library changes for `did:web` DID support and JWK public key registration.

### Changes

- **did:web derivation** — Both `BadgeService` and `SimpleGuardService` now prefer `did:web:<host>:agents:<id>` when server URL and agent ID are available, falling back to `did:key` for offline/dev mode.
- **JWK registration** — `registerDIDWithServer()` now sends the agent's public JWK alongside the DID in `PATCH /v1/sdk/agents/{id}/identity`, enabling the server to store verifiable keys.
- **Guard optimization** — Badge verification skips online revocation and agent-status checks. Badges are short-lived (5-min TTL) and `BadgeKeeper` manages freshness. This preserves the sub-millisecond design goal for per-tool-call verification.

- ### Related PRs

- capiscio-server: `feat/jwk-didweb-support` (VerifiedLevel cap, enable/disable fixes)
- capiscio-sdk-python: `feat/didweb-transition` (DID method transition handling)"