### PR TITLE
fix: respect private_key_path in keeper and nil-check badge verifier

### DIFF
--- a/internal/rpc/badge_service.go
+++ b/internal/rpc/badge_service.go
@@ -659,20 +659,26 @@ func (s *BadgeService) configureCAMode(config *badge.KeeperConfig, req *pb.Start
 		caURL = badge.DefaultCAURL
 	}
 
-	// Try to load the agent's private key from the standard keys directory.
-	// The SDK's Init RPC stores keys at ~/.capiscio/keys/{agent_id}/private.jwk.
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("cannot determine home directory: %w", err)
-	}
+	// Load the agent's private key.
+	// Prefer the explicit path from the SDK (private_key_path), fall back to
+	// the standard keys directory (~/.capiscio/keys/{agent_id}/private.jwk).
+	var privKeyPath string
+	if req.PrivateKeyPath != "" {
+		privKeyPath = req.PrivateKeyPath
+	} else {
+		homeDir, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("cannot determine home directory: %w", err)
+		}
 
-	// Sanitize agent_id to prevent path traversal
-	cleanID := filepath.Base(req.AgentId)
-	if cleanID == "." || cleanID == ".." || cleanID == "/" || cleanID != req.AgentId {
-		return fmt.Errorf("invalid agent_id: contains path separators or traversal sequences")
-	}
+		// Sanitize agent_id to prevent path traversal
+		cleanID := filepath.Base(req.AgentId)
+		if cleanID == "." || cleanID == ".." || cleanID == "/" || cleanID != req.AgentId {
+			return fmt.Errorf("invalid agent_id: contains path separators or traversal sequences")
+		}
 
-	privKeyPath := filepath.Join(homeDir, ".capiscio", "keys", cleanID, "private.jwk")
+		privKeyPath = filepath.Join(homeDir, ".capiscio", "keys", cleanID, "private.jwk")
+	}
 	keyData, err := os.ReadFile(privKeyPath)
 	if err != nil {
 		return fmt.Errorf("failed to read agent private key at %s: %w", privKeyPath, err)

--- a/pkg/mcp/server_identity.go
+++ b/pkg/mcp/server_identity.go
@@ -126,6 +126,12 @@ func (v *ServerIdentityVerifier) VerifyServerIdentity(
 
 	// Step 6: Verify server badge using badge.Verifier (RFC-007 §7.2.3)
 	// This is the SAME verification path as agent badges - unified identity infrastructure
+	if v.badgeVerifier == nil {
+		result.State = ServerStateUnverifiedOrigin
+		result.ErrorCode = ServerErrorCodeBadgeInvalid
+		result.ErrorDetail = "badge verifier not initialized (CAPISCIO_REGISTRY_ENDPOINT not set)"
+		return result, nil
+	}
 	badgeResult, err := v.badgeVerifier.VerifyWithOptions(ctx, serverBadgeJWS, badge.VerifyOptions{
 		// Server badges use the same verification as agent badges
 	})

--- a/pkg/mcp/server_identity.go
+++ b/pkg/mcp/server_identity.go
@@ -129,7 +129,7 @@ func (v *ServerIdentityVerifier) VerifyServerIdentity(
 	if v.badgeVerifier == nil {
 		result.State = ServerStateUnverifiedOrigin
 		result.ErrorCode = ServerErrorCodeBadgeInvalid
-		result.ErrorDetail = "badge verifier not initialized (CAPISCIO_REGISTRY_ENDPOINT not set)"
+		result.ErrorDetail = "badge verifier not configured — set CAPISCIO_REGISTRY_ENDPOINT or CAPISCIO_TRUST_STORE_KEY"
 		return result, nil
 	}
 	badgeResult, err := v.badgeVerifier.VerifyWithOptions(ctx, serverBadgeJWS, badge.VerifyOptions{


### PR DESCRIPTION
## Summary

Two bug fixes that unblock SDK PoP (IAL-1) badge support and prevent crashes in MCP client verification.

## Changes

### `internal/rpc/badge_service.go`
The `configureCAMode()` helper now checks `req.PrivateKeyPath` first. When the SDK passes a custom key path (e.g. from a project-local `keys_dir`), the keeper uses it directly instead of constructing `~/.capiscio/keys/{agentId}/private.jwk`.

Falls back to the existing hardcoded path when `PrivateKeyPath` is empty (backward compatible).

### `pkg/mcp/server_identity.go`
Added nil check for `badgeVerifier` before calling `VerifyWithOptions()`. When `CAPISCIO_REGISTRY_ENDPOINT` is not set, `badgeVerifier` is nil — previously this caused a nil pointer panic. Now returns `ServerStateUnverifiedOrigin` with a descriptive error message.

## Testing

- Verified via enforcement-demo (5/5 scenarios passing)
- Verified via policy-demo (badge acquisition + MCP client connection succeed)
- `make build-cli` compiles cleanly