### PR TITLE
chore: bump version to 2.7.1 for patch release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.7.1] - 2026-05-14
+
+### Fixed
+- Respect `private_key_path` in badge keeper RPC — use client-provided path instead of hardcoded default (#81)
+- Nil-check badge verifier in MCP server identity to prevent panic when verifier is not configured (#81)
+- Improve error message clarity when badge verifier is missing (mentions both config options) (#81)
+
 ## [2.7.0] - 2026-05-13
 
 ### Added

--- a/cmd/capiscio/main.go
+++ b/cmd/capiscio/main.go
@@ -9,7 +9,7 @@ import (
 )
 
 var (
-	version = "2.7.0"
+	version = "2.7.1"
 	commit  = "unknown"
 )
 

--- a/pkg/mcp/health.go
+++ b/pkg/mcp/health.go
@@ -8,7 +8,7 @@ import (
 
 const (
 	// CoreVersion is the capiscio-core version
-	CoreVersion = "2.7.0"
+	CoreVersion = "2.7.1"
 
 	// ProtoVersion is the MCP proto schema version
 	ProtoVersion = "1.0"


### PR DESCRIPTION
Patch release prep for v2.7.1.

**Changes:**
- Bump version constant `2.7.0` → `2.7.1` in `cmd/capiscio/main.go`
- Add v2.7.1 entry to CHANGELOG.md

**Context:**
This follows the merge of #81 (fix: respect private_key_path in keeper and nil-check badge verifier). The patch fixes:
1. Keeper RPC now respects client-provided `private_key_path` instead of using hardcoded default
2. Nil-check for badge verifier in MCP server identity prevents panic
3. Improved error message when badge verifier is missing

Needed before PyCon (May 15).