### PR TITLE
fix: badge verify file support, JTI in self-sign, init SDK endpoint

### DIFF
--- a/cmd/capiscio/badge.go
+++ b/cmd/capiscio/badge.go
@@ -471,13 +471,18 @@ func requestBadgeFromCA() error {
 		return &AuthRequiredError{
 			Command: "badge keep",
 			Message: "Invalid or expired API key",
-			Help: `Your API key was rejected. Please check:
+			Help: `Your API key was rejected. CA mode requires a dashboard session token,
+not an SDK registry key (sk_live_/sk_test_).
 
-  1. The API key is correct (starts with sk_live_ or sk_test_)
-  2. The API key has not been revoked
-  3. You have permission to manage this agent
+For SDK key authentication, use one of these alternatives:
 
-Get a new API key at https://app.capisc.io/api-keys`,
+  # Self-signed badges (development/testing)
+  capiscio badge keep --self-sign --key private.jwk
+
+  # PoP badges (production, requires registered agent with DID)
+  capiscio badge keep --pop --agent-did did:key:... --key private.jwk
+
+Get a dashboard token at https://app.capisc.io`,
 		}
 	}
 	
@@ -592,6 +597,15 @@ Examples:
 	Args: cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		token := args[0]
+
+		// If the argument looks like a file path, read the token from the file
+		if _, err := os.Stat(token); err == nil {
+			data, err := os.ReadFile(token)
+			if err != nil {
+				return fmt.Errorf("failed to read badge file %s: %w", token, err)
+			}
+			token = strings.TrimSpace(string(data))
+		}
 
 		// Build verification options
 		opts := badge.VerifyOptions{

--- a/cmd/capiscio/badge.go
+++ b/cmd/capiscio/badge.go
@@ -470,9 +470,9 @@ func requestBadgeFromCA() error {
 	if resp.StatusCode == http.StatusUnauthorized {
 		return &AuthRequiredError{
 			Command: "badge keep",
-			Message: "Invalid or expired API key",
-			Help: `Your API key was rejected. CA mode requires a dashboard session token,
-not an SDK registry key (sk_live_/sk_test_).
+			Message: "Authentication rejected — CA mode requires a dashboard session token",
+			Help: `CA mode requires a dashboard session token, not an SDK registry key
+(sk_live_/sk_test_).
 
 For SDK key authentication, use one of these alternatives:
 
@@ -599,7 +599,7 @@ Examples:
 		token := args[0]
 
 		// If the argument looks like a file path, read the token from the file
-		if _, err := os.Stat(token); err == nil {
+		if fi, err := os.Stat(token); err == nil && fi.Mode().IsRegular() {
 			data, err := os.ReadFile(token)
 			if err != nil {
 				return fmt.Errorf("failed to read badge file %s: %w", token, err)

--- a/cmd/capiscio/init.go
+++ b/cmd/capiscio/init.go
@@ -321,11 +321,11 @@ func printInitSummary(agentID, didKey, outputDir string) {
 
 // fetchFirstAgent fetches the first agent from the registry
 func fetchFirstAgent(serverURL, apiKey string) (id string, name string, err error) {
-	req, err := http.NewRequest("GET", serverURL+"/v1/agents", nil)
+	req, err := http.NewRequest("GET", serverURL+"/v1/sdk/agents", nil)
 	if err != nil {
 		return "", "", err
 	}
-	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("X-Capiscio-Registry-Key", apiKey)
 	req.Header.Set("Content-Type", "application/json")
 
 	client := &http.Client{Timeout: 30 * time.Second}

--- a/cmd/capiscio/init_test.go
+++ b/cmd/capiscio/init_test.go
@@ -8,7 +8,6 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/capiscio/capiscio-core/v2/pkg/did"
@@ -113,10 +112,10 @@ func TestCreateAgentCardShortID(t *testing.T) {
 func TestFetchFirstAgent(t *testing.T) {
 	// Mock server that returns an agent list
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == "/v1/agents" {
-			// Check auth header (Bearer token)
-			authHeader := r.Header.Get("Authorization")
-			if authHeader == "" || !strings.HasPrefix(authHeader, "Bearer ") {
+		if r.URL.Path == "/v1/sdk/agents" {
+			// Check auth header (SDK registry key)
+			authHeader := r.Header.Get("X-Capiscio-Registry-Key")
+			if authHeader == "" {
 				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}

--- a/pkg/badge/keeper.go
+++ b/pkg/badge/keeper.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/go-jose/go-jose/v4"
+	"github.com/google/uuid"
 )
 
 // KeeperMode defines the mode of operation for the keeper.
@@ -281,6 +282,7 @@ func (k *Keeper) renewFromCA() (*RenewalResult, error) {
 func (k *Keeper) renewSelfSign() (*RenewalResult, error) {
 	now := time.Now()
 	newClaims := k.config.Claims
+	newClaims.JTI = uuid.New().String()
 	newClaims.IssuedAt = now.Unix()
 	newClaims.Expiry = now.Add(k.config.Expiry).Unix()
 


### PR DESCRIPTION
## DX Audit Fixes

Found during a hands-on DX walkthrough of the getting-started docs with real API calls.

### Changes

**1. `badge verify` now reads from file paths (Bug #2 — High)**

`capiscio badge verify ./badge.jwt` was treating the filename as a raw JWS token and failing with `BADGE_MALFORMED`. Now detects file paths via `os.Stat()` and reads the content. Passing raw tokens inline still works unchanged.

**2. Self-signed badge renewal now sets JTI (Bug #3 — High)**

`Keeper.renewSelfSign()` was producing badges with empty JTI, causing verification failures. Added `uuid.New().String()` for the JTI claim before signing.

**3. `capiscio init` uses SDK endpoint (Bug #4 — High)**

When `--agent-id` is omitted, `init` fetches the first agent from the registry. It was calling `/v1/agents` with `Authorization: Bearer` (Clerk dashboard auth), which returns 401 for SDK keys. Changed to `/v1/sdk/agents` with `X-Capiscio-Registry-Key` header.

**4. Improved 401 error message for `badge keep`**

The CA badge endpoint requires a dashboard session token, not an SDK key. Updated the error message to explain this and suggest `--self-sign` or `--pop` alternatives.

### Breaking Changes

None. File detection is additive (os.Stat failure falls through). JTI was empty before (a bug). Init endpoint change fixes a path that was always 401ing for SDK keys.

### Testing

- `badge verify ./badge.jwt --accept-self-signed` reads file and verifies ✅
- Self-signed badge has UUID JTI ✅
- `capiscio init` with `CAPISCIO_API_KEY=sk_live_...` lists agents from real registry ✅
- All unit tests pass (`TestFetchFirstAgent` updated for new endpoint)