### PR TITLE
ci: trigger E2E tests on merge to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,3 +120,17 @@ jobs:
         with:
           name: gosec-results
           path: gosec-results.json
+
+  trigger-e2e:
+    name: Trigger E2E Tests
+    needs: [test]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dispatch E2E workflow
+        uses: peter-evans/repository-dispatch@v3
+        with:
+          token: ${{ secrets.REPO_ACCESS_TOKEN }}
+          repository: capiscio/capiscio-e2e-tests
+          event-type: upstream-merge
+          client-payload: '{"repo": "capiscio-core", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Adds a `trigger-e2e` job that dispatches `repository_dispatch` to `capiscio/capiscio-e2e-tests` after the `test` job passes on pushes to `main`.

This closes the gap where merges to capiscio-core could only be caught by the daily 6am E2E cron — regressions now trigger cross-product E2E within minutes.

Requires `REPO_ACCESS_TOKEN` secret (already configured in capiscio-e2e-tests CI).